### PR TITLE
Console 1.31.1 update Kubernetes Compatibility matrix

### DIFF
--- a/docs/platform/get-started/installation/get-started/kubernetes.md
+++ b/docs/platform/get-started/installation/get-started/kubernetes.md
@@ -65,7 +65,8 @@ Breaking changes:
 
 | Chart version | Supported Platform version | Breaking changes |
 | ------------- | ------------------------- | ---------------- |
-| [console-1.16.0](https://github.com/conduktor/conduktor-public-charts/releases/tag/console-1.15.0) | **1.31.0**, 1.30.0, 1.29.2, 1.29.1, 1.29.0, 1.28.0, 1.27.1, 1.27.0, 1.26.0, 1.25.1, 1.25.0, 1.24.1, 1.24.0 | |
+| [console-1.16.1](https://github.com/conduktor/conduktor-public-charts/releases/tag/console-1.16.1) | **1.31.1**, 1.31.0, 1.30.0, 1.29.2, 1.29.1, 1.29.0, 1.28.0, 1.27.1, 1.27.0, 1.26.0, 1.25.1, 1.25.0, 1.24.1, 1.24.0 | |
+| [console-1.16.0](https://github.com/conduktor/conduktor-public-charts/releases/tag/console-1.16.0) | **1.31.0**, 1.30.0, 1.29.2, 1.29.1, 1.29.0, 1.28.0, 1.27.1, 1.27.0, 1.26.0, 1.25.1, 1.25.0, 1.24.1, 1.24.0 | |
 | [console-1.15.0](https://github.com/conduktor/conduktor-public-charts/releases/tag/console-1.15.0) | **1.30.0**, 1.29.2, 1.29.1, 1.29.0, 1.28.0, 1.27.1, 1.27.0, 1.26.0, 1.25.1, 1.25.0, 1.24.1, 1.24.0 | |
 | [console-1.14.2](https://github.com/conduktor/conduktor-public-charts/releases/tag/console-1.14.2) | **1.29.2**, 1.29.1, 1.29.0, 1.28.0, 1.27.1, 1.27.0, 1.26.0, 1.25.1, 1.25.0, 1.24.1, 1.24.0 | |
 | [console-1.14.1](https://github.com/conduktor/conduktor-public-charts/releases/tag/console-1.14.1) | **1.29.1**, 1.29.0, 1.28.0, 1.27.1, 1.27.0, 1.26.0, 1.25.1, 1.25.0, 1.24.1, 1.24.0 | |


### PR DESCRIPTION
Updated the K8s compatability matrix to include new Helm Release. Fixed link for 1.16.0