### PR TITLE
Kafka 4.0.0 current limitation

### DIFF
--- a/docs/gateway/get-started/system-requirements.md
+++ b/docs/gateway/get-started/system-requirements.md
@@ -38,7 +38,7 @@ Conduktor Gateway is **designed to scale horizontally or vertically**, as requir
 
 Depending on your needs and use cases, one or both of these methods may be used to get the best out of Conduktor. Multiple instances of Gateway can be run as a cluster and Gateway will handle the load balancing and other work distribution concerns between the nodes in a cluster.
 
-Gateway is predominantly CPU bound - it stores very little, unless you've configured or adjusted the default caching setup. The recommendation here represents a good starting point - to further scale you should use the metrics produced by gateway to tune the installation to your workloads. 
+Gateway is predominantly CPU bound - it stores very little, unless you've configured or adjusted the default caching setup. The recommendation here represents a good starting point - to further scale you should use the metrics produced by gateway to tune the installation to your workloads.
 
 ### Interceptor impact
 
@@ -50,9 +50,9 @@ For high CPU loads, you should also add more memory in addition to cores. We rec
 
 ## Kafka requirements
 
-Conduktor Gateway requires Apache Kafka version 2.5.0 or higher. Gateway should connect to Kafka as an 'admin user'. 
+Conduktor Gateway requires Apache Kafka version to be 2.5.0 or higher, and lower than version 4.0.0.
 
-As a minimum, this user should have access to:
+Gateway should connect to Kafka as an 'admin user'. At a minimum, this user should have access to:
 
 - manage topics and consumer groups
 - commit offsets

--- a/docs/platform/get-started/installation/hardware.md
+++ b/docs/platform/get-started/installation/hardware.md
@@ -25,6 +25,7 @@ To ensure you meet these requirements, you must:
   - Note we recommend configuring your PostgreSQL database for [high-availability](#database-connection-fail-over)
 - Setup [block storage](/platform/get-started/configuration/env-variables#monitoring-properties) (S3, GCS, Azure, Swift) to store metrics data required for Monitoring
 - Meet the [hardware requirements](#hardware-requirements) so that Conduktor has sufficient resources to run without issue
+- Running Apache Kafka version 2.5.0 or higher, and lower than version 4.0.0
 
 Note that if you are deploying the [Helm chart](/platform/get-started/installation/get-started/kubernetes/), the [production requirements](/platform/get-started/installation/get-started/kubernetes#production-requirements) are clearly outlined in the installation guide.
 

--- a/docs/platform/get-started/installation/hardware.md
+++ b/docs/platform/get-started/installation/hardware.md
@@ -9,35 +9,36 @@ description: Conduktor Console is provided as a single Docker container.
 Conduktor Console is provided as a single Docker container.
 
 Jump to:
- - [Production Requirements](#production-requirements)
- - [Hardware Requirements](#hardware-requirements)
- - [Deployment Architecture](#deployment-architecture)
+
+- [Production Requirements](#production-requirements)
+- [Hardware Requirements](#hardware-requirements)
+- [Deployment Architecture](#deployment-architecture)
 
 ## Production Requirements
 
-For production environments, there are **mandatory requirements** to ensure your deployment is **reliable**, **durable**, and **can be recovered easily**. 
+For production environments, there are **mandatory requirements** to ensure your deployment is **reliable**, **durable**, and **can be recovered easily**.
 
 To ensure you meet these requirements, you must:
 
- - Set up an [external PostgreSQL (13+) database](/platform/get-started/configuration/database/) with appropriate backup policy 
-    - This is used to store data relating to your Conduktor deployment; such as your users, permissions, tags and configurations
-    - Note we recommend configuring your PostgreSQL database for [high-availability](#database-connection-fail-over)
- - Setup [block storage](/platform/get-started/configuration/env-variables#monitoring-properties) (S3, GCS, Azure, Swift) to store metrics data required for Monitoring
- - Meet the [hardware requirements](#hardware-requirements) so that Conduktor has sufficient resources to run without issue
- 
-Note that if you are deploying the [Helm chart](/platform/get-started/installation/get-started/kubernetes/), the [production requirements](/platform/get-started/installation/get-started/kubernetes#production-requirements) are clearly outlined in the installation guide. 
+- Set up an [external PostgreSQL (13+) database](/platform/get-started/configuration/database/) with appropriate backup policy
+  - This is used to store data relating to your Conduktor deployment; such as your users, permissions, tags and configurations
+  - Note we recommend configuring your PostgreSQL database for [high-availability](#database-connection-fail-over)
+- Setup [block storage](/platform/get-started/configuration/env-variables#monitoring-properties) (S3, GCS, Azure, Swift) to store metrics data required for Monitoring
+- Meet the [hardware requirements](#hardware-requirements) so that Conduktor has sufficient resources to run without issue
+
+Note that if you are deploying the [Helm chart](/platform/get-started/installation/get-started/kubernetes/), the [production requirements](/platform/get-started/installation/get-started/kubernetes#production-requirements) are clearly outlined in the installation guide.
 
 ## Hardware Requirements
 
 To configure Conduktor Console for particular hardware, you can use container CGroups limits. More details [here](/platform/get-started/configuration/memory-configuration)
 
-**Minimum**
+### Minimum
 
 - 2 CPU cores
 - 3 GB of RAM
 - 5 GB of disk space
 
-**Recommended**
+### Recommended
 
 - 4+ CPU cores
 - 4+ GB of RAM
@@ -88,21 +89,22 @@ In the pre-1.25.0 architecture, Kafka Monitoring maintained its state in-memory.
 #### Multiple Instances (Post-Console 1.25.0)
 
 From Console 1.25.0 onwards, the monitoring state is now stored in the external PostgreSQL database, allowing the state to be shared and accessed by all instances of Console. This change brings several advantages:
- - **Consistency**: Multiple Console instances can now deployed with a leader elected to handle the stateful components (Kafka [Metadata Indexer](/platform/navigation/console/about-indexing/) and Monitoring).
- - **Redundancy & Fault Tolerance**: If the leader instance fails, another instance takes over as the leader, without losing any monitoring data.
- - **Prometheus Metrics**: Every Console instance is now capable of exposing [Prometheus metrics](/platform/reference/metric-reference/) through the API. This allows for real-time monitoring of the application regardless of which instance is the leader, as the monitoring state is available to all instances.
 
- ### High-Availability Limitations
+- **Consistency**: Multiple Console instances can now deployed with a leader elected to handle the stateful components (Kafka [Metadata Indexer](/platform/navigation/console/about-indexing/) and Monitoring).
+- **Redundancy & Fault Tolerance**: If the leader instance fails, another instance takes over as the leader, without losing any monitoring data.
+- **Prometheus Metrics**: Every Console instance is now capable of exposing [Prometheus metrics](/platform/reference/metric-reference/) through the API. This allows for real-time monitoring of the application regardless of which instance is the leader, as the monitoring state is available to all instances.
+
+### High-Availability Limitations
 
  While the architecture introduced in Console 1.25 greatly improves the **UI layers horizontal scalability**, there are notable limitations related to the use of Cortex for metrics storage.
 
-#### Cortex in Standalone Mode 
+#### Cortex in Standalone Mode
 
 The system currently uses Cortex in standalone mode, which does not inherently provide high availability. The implications of this limitation are:
 
- - **Metrics Unavailability**: In the event of a Cortex failure, monitoring data inside Console might not be accessible until the container is restarted.
- - **Alerting Unavailability**: In the event of a Cortex failure, alerting functionality inside Console will not be present until the container is restarted.
- - **No Redundancy**: Without a multi-node or clustered setup for Cortex, the system lacks the resilience and failover capabilities that are present in other components like Console and PostgreSQL.
+- **Metrics Unavailability**: In the event of a Cortex failure, monitoring data inside Console might not be accessible until the container is restarted.
+- **Alerting Unavailability**: In the event of a Cortex failure, alerting functionality inside Console will not be present until the container is restarted.
+- **No Redundancy**: Without a multi-node or clustered setup for Cortex, the system lacks the resilience and failover capabilities that are present in other components like Console and PostgreSQL.
 
 #### Database Connection Fail-over
 
@@ -111,28 +113,8 @@ Since version 1.30 Console supports using multiple database URLs in configuratio
 For Conduktor configuration details see [Multi-host database configuration](docs/platform/get-started/configuration/database.md#multi-host-configuration) which supports multiple hosts.
 For Postgresql HA configuration it's best to discuss with your architect, one example is using [Bitnami's postgresql-ha chart](https://github.com/bitnami/charts/blob/main/bitnami/postgresql-ha/README.md#differences-between-the-postgresql-ha-and-postgresql-helm-charts).
 
-
 In earlier versions we recommend instead that you configure an HA Postgres database where you should specify the single connection URL (e.g. the endpoint of PgBouncer or HAProxy) in the Conduktor Console database configuration. There are several solutions available such as:
- 
- - [**Patroni**](https://www.cybertec-postgresql.com/en/patroni-setting-up-a-highly-available-postgresql-cluster/): Automates Postgres replication and failover
- - **PgBouncer** or **HAProxy**: For connection pooling and distributing connections across multiple Postgres instances
- - **Cloud-managed solutions**: Managed Postgres services like AWS RDS, Google Cloud SQL, or Azure Database for PostgreSQL often provide built-in HA
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+- [**Patroni**](https://www.cybertec-postgresql.com/en/patroni-setting-up-a-highly-available-postgresql-cluster/): Automates Postgres replication and failover
+- **PgBouncer** or **HAProxy**: For connection pooling and distributing connections across multiple Postgres instances
+- **Cloud-managed solutions**: Managed Postgres services like AWS RDS, Google Cloud SQL, or Azure Database for PostgreSQL often provide built-in HA


### PR DESCRIPTION
Document how we don't support 4.0.0, for now.

> "localizedMessage":"The API_VERSIONS protocol does not support version 4","message":"The API_VERSIONS protocol does not support version 4"