### PR TITLE
Markdown link action config

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,11 @@
+{
+  "aliveStatusCodes": [429, 200],
+  "httpHeaders": [
+    {
+      "urls": ["https://github.com/", "https://guides.github.com/", "https://help.github.com/", "https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Do not fail on 429 - this is a too many requests status code and just means the runner has tried to fetch the same link too many times and the host is limiting it. (Also in a weird way is a pretty strong indication the URL is a live if it's subject to limits).

Creates a lot of false noise otherwise.

I also added some suggested config from the action docs: https://github.com/marketplace/actions/markdown-link-check