### PR TITLE
feat: new policy_ref field added to application instance

### DIFF
--- a/docs/platform/reference/resource-reference/self-service.md
+++ b/docs/platform/reference/resource-reference/self-service.md
@@ -174,6 +174,9 @@ resource "conduktor_console_application_instance_v1" "clickstream-dev" {
       "generic-dev-topic",
       "clickstream-naming-rule"
     ]
+    policy_ref = [
+      "generic-resource-policy"
+    ]
     default_catalog_visibility = "PUBLIC"
     resources = [
       {


### PR DESCRIPTION
Adding new `spec.policy_ref` field to `conduktor_console_application_instance_v1` example doc.