### PR TITLE
1.36 Trust docs

### DIFF
--- a/docs/platform/navigation/data-quality/index.md
+++ b/docs/platform/navigation/data-quality/index.md
@@ -219,7 +219,7 @@ Once a Policy is created, you can view the linked Rule(s), the target(s) and cha
 Since the **block** action has the ability to **stop data from being sent** to the requested topic, you have to confirm this by entering 'BLOCK' when prompted. Conversely, to disable the blocking, enter 'UNBLOCK' when prompted.
 :::
 
-When editing a Policy from its details page, you can update its name, description and targets. You can't edit the linked Rules of a Policy from this view.
+When editing a Policy from its details page, you can update its name, description and targets. You can't edit the linked Rules of a Policy.
 
 ### Assign permissions
 

--- a/docs/platform/navigation/data-quality/index.md
+++ b/docs/platform/navigation/data-quality/index.md
@@ -27,7 +27,7 @@ You can create Rules with the Common Expression Language (CEL) expressions which
 Rules do nothing on their own - you **have to** to attach them to a Policy.
 :::
 
-The Rules page lists your Rules, with a preview of their CEL expressions. Open Rule's detail page to see its description, full CEL expression and attached Policies.
+The Rules page lists your Rules, with a preview of their CEL expressions. On a Rule's detail page you can view its description, full CEL expression, attached Policies and create a new Policy with the current Rule pre-selected.
 
 ### Create a Rule
 
@@ -81,13 +81,21 @@ We provide built-in validation Rules that can't be achieved with CEL.
 We currently only support **Confluent** and **Confluent like** (e.g. Redpanda) schema registries.
 :::
 
-#### EnforceAvro
+#### Enforce Avro
 
-`EnforceAvro` ensures that:
+Enforce Avro ensures that:
 
 - Your messages have a schema ID prepended to the message content.
 - The schema ID exists within your schema registry.
 - The schema it references is of type `avro`.
+
+#### Enforce schema ID
+
+Enforce schema ID ensures that:
+
+- Your messages have a schema ID prepended to the message content.
+
+It does not check your schema registry.
 
 ### Sample Rules
 
@@ -118,15 +126,20 @@ Make sure you amend these examples to use your values.
   </p>
 </details>
 
+### Editing Rules
+
+You can only edit Rules that have not been used in any Policies, and you cannot edit any built-in Rules.
+When editing a Rule from its details page, you can update its name, description and CEL expression.
+
 ## Policies
 
 A Policy is made up of Rules that are applied to topics/prefixes.
 
 Once created, Policies can be assigned [actions](#actions) to take effect when certain criteria is met (e.g., a Rule in the Policy is violated).
 
-The Policy's detail page shows its description, linked Rules, targets, the number of messages evaluated and the number of violations since the Policy was created. You can also enable (and disable) actions for the Policy from this page.
+The Policy's detail page shows its description, linked Rules, targets, the number of messages evaluated and the number of violations over time. You can also enable (and disable) actions for the Policy from this page, and see the status of its deployment on target clusters.
 
-The Policies page lists your Policies with their actions and targets.
+The Policies page lists your Policies with their actions, targets, and displays the number of violations for each policy within the time window selected at the top of the page.
 
 ### Actions
 
@@ -206,6 +219,8 @@ Once a Policy is created, you are able to view the linked Rule(s), the target(s)
 :::info[Enabling block action]
 Since the **block** action has the ability to **stop data from being sent** to the requested topic, you have to confirm this by entering 'BLOCK' when prompted. Conversely, to disable the blocking, enter 'UNBLOCK' when prompted.
 :::
+
+When editing a Policy you can update its name, description, and targets. You cannot edit the linked Rules of a Policy.
 
 ### Assign permissions
 

--- a/docs/platform/navigation/data-quality/index.md
+++ b/docs/platform/navigation/data-quality/index.md
@@ -27,7 +27,7 @@ You can create Rules with the Common Expression Language (CEL) expressions which
 Rules do nothing on their own - you **have to** to attach them to a Policy.
 :::
 
-The Rules page lists your Rules, with a preview of their CEL expressions. On a Rule's detail page you can view its description, full CEL expression, attached Policies and create a new Policy with the current Rule pre-selected.
+The Rules page lists your Rules and shows a preview of their CEL expressions. The details page shows the selected Rule's description, full CEL expression, attached Policies and allows you to create a new Policy with this Rule pre-selected.
 
 ### Create a Rule
 
@@ -73,6 +73,12 @@ You can also use the [Conduktor CLI](/gateway/reference/cli-reference/) to creat
 </TabItem>
 </Tabs>
 
+### Edit a Rule
+
+You can only edit Rules that aren't used in any Policies and you can't edit [built-in Rules](#built-in-rules).
+
+When editing a Rule from its details page, you can update its name, description and CEL expression.
+
 ### Built-in Rules
 
 We provide built-in validation Rules that can't be achieved with CEL.
@@ -83,19 +89,17 @@ We currently only support **Confluent** and **Confluent like** (e.g. Redpanda) s
 
 #### Enforce Avro
 
-Enforce Avro ensures that:
+This Rule ensures that:
 
-- Your messages have a schema ID prepended to the message content.
-- The schema ID exists within your schema registry.
-- The schema it references is of type `avro`.
+- your messages have a schema ID prepended to the message content,
+- the schema ID exists within your schema registry and
+- the schema it references is of type `avro`.
 
 #### Enforce schema ID
 
-Enforce schema ID ensures that:
+This Rule ensures that your messages have a schema ID prepended to the message content.
 
-- Your messages have a schema ID prepended to the message content.
-
-It does not check your schema registry.
+It doesn't check your schema registry.
 
 ### Sample Rules
 
@@ -126,20 +130,15 @@ Make sure you amend these examples to use your values.
   </p>
 </details>
 
-### Editing Rules
-
-You can only edit Rules that have not been used in any Policies, and you cannot edit any built-in Rules.
-When editing a Rule from its details page, you can update its name, description and CEL expression.
-
 ## Policies
 
 A Policy is made up of Rules that are applied to topics/prefixes.
 
 Once created, Policies can be assigned [actions](#actions) to take effect when certain criteria is met (e.g., a Rule in the Policy is violated).
 
-The Policy's detail page shows its description, linked Rules, targets, the number of messages evaluated and the number of violations over time. You can also enable (and disable) actions for the Policy from this page, and see the status of its deployment on target clusters.
+The Policy's detail page shows its description, linked Rules, targets, the number of messages evaluated and the number of violations over time. You can also enable (and disable) actions for the Policy from this page and see the status of its deployment on target clusters.
 
-The Policies page lists your Policies with their actions, targets, and displays the number of violations for each policy within the time window selected at the top of the page.
+The Policies page lists your Policies with their actions and targets, as well as the number of violations that occurred for each policy within the selected timeframe.
 
 ### Actions
 
@@ -214,13 +213,13 @@ You can also use the [Conduktor CLI (Command Line Interface)](/gateway/reference
 
 ### Manage a Policy
 
-Once a Policy is created, you are able to view the linked Rule(s), the target(s) of the Policy and change the [actions](#actions) of the Policy. You can also view the violations as they have occurred if you have reporting enabled, otherwise you will only have the counts available.
+Once a Policy is created, you can view the linked Rule(s), the target(s) and change the [actions](#actions) of the Policy. If **Report** is enabled, you can also view the violations as they've occurred, otherwise only the violation count will be shown.
 
 :::info[Enabling block action]
 Since the **block** action has the ability to **stop data from being sent** to the requested topic, you have to confirm this by entering 'BLOCK' when prompted. Conversely, to disable the blocking, enter 'UNBLOCK' when prompted.
 :::
 
-When editing a Policy you can update its name, description, and targets. You cannot edit the linked Rules of a Policy.
+When editing a Policy from its details page, you can update its name, description and targets. You can't edit the linked Rules of a Policy from this view.
 
 ### Assign permissions
 


### PR DESCRIPTION
new functionality captured:
- edit rules
- edit policies
- violation stats are no longer "all-time" stats
- cluster deployment status on policy targets
- new 'enforce schema id' built-in rule
- create new policy with rule pre-selected