### PR TITLE
Update example env injection by file for Gateway

### DIFF
--- a/docs/gateway/configuration/env-variables.md
+++ b/docs/gateway/configuration/env-variables.md
@@ -59,13 +59,13 @@ gateway:
 
 ### Use a file
 
-You can mount a file with the key-value pairs into the container and provide its path by setting the environment variable `GATEWAY_ENV_FILE`.
+You can mount a file with the key-value pairs into the container and provide its path by setting the environment variable `GATEWAY_ENV_FILE`. Note these variables should be exported by the file as they are injected in the wrapper that starts the Gateway process.
 
 ```env title="Example"
-KAFKA_BOOTSTRAP_SERVERS=kafka1:9092,kafka2:9092
-KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
-KAFKA_SASL_MECHANISM=PLAIN
-KAFKA_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username='usr' password='pwd';
+export KAFKA_BOOTSTRAP_SERVERS=kafka1:9092,kafka2:9092
+export KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
+export KAFKA_SASL_MECHANISM=PLAIN
+export KAFKA_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username='usr' password='pwd';
 ```
 
 You'll get a confirmation in the logs: `Sourcing environment variables from $GATEWAY_ENV_FILE` (or a warning if the file isn't found: `Warning: GATEWAY_ENV_FILE is set but the file does not exist or is not readable.`).


### PR DESCRIPTION
Update the example in the docs on how to inject environment variables from a file for the Gateway. The previous example did not work as it was missing the fact each variable needs to be exported (as in use a Bash shell `export` command)