### PR TITLE
Serve the 3rd party deps pdf from s3

### DIFF
--- a/guide/support/third-party-dependencies.mdx
+++ b/guide/support/third-party-dependencies.mdx
@@ -5,7 +5,7 @@ keywords: ['software licenses', 'open source', 'dependencies']
 
 Conduktor relies on third-party software libraries.
 
-[View the dependencies as a .pdf document](/static/assets/documents/conduktor-platform-3rd-party-dependencies.pdf). 
+[View the dependencies as a .pdf document](https://cdn.conduktor.io/reports/conduktor-platform-3rd-party-dependencies.pdf). 
 
 <Note>
 Information in this document is subject to updates.


### PR DESCRIPTION
Serving the file from mintlify isn't working after deployment (it works locally). We can serve the pdf from s3.