### PR TITLE
Add support of userPrincipalName for the email in LDAP

### DIFF
--- a/guide/conduktor-in-production/admin/user-access/configure-sso.mdx
+++ b/guide/conduktor-in-production/admin/user-access/configure-sso.mdx
@@ -55,14 +55,14 @@ If your LDAP server is **Active Directory** and you get an "invalid user" error 
 
 Here is the mapping between LDAP user's information and Conduktor Console:
 
-| LDAP              | Conduktor Console                         |
-| ----------------- | ----------------------------------------- |
-| `uid`             | User ID, used to log in                   |
-| `mail` or `email` | User email (**The only mandatory field**) |
-| `cn`              | User name                                 |
-| `sn`              | User family name                          |
-| `givenName`       | User first name                           |
-| `displayName`     | User display name                         |
+| LDAP                                   | Conduktor Console                         |
+|----------------------------------------|-------------------------------------------|
+| `uid`                                  | User ID, used to log in                   |
+| `mail`, `email` or `userPrincipalName` | User email (**The only mandatory field**) |
+| `cn`                                   | User name                                 |
+| `sn`                                   | User family name                          |
+| `givenName`                            | User first name                           |
+| `displayName`                          | User display name                         |
 
 #### Groups
 


### PR DESCRIPTION
Since 1.32, we support userPrincipalName to get the user email.
Before:
<img width="382" height="241" alt="image" src="https://github.com/user-attachments/assets/476e727f-e37a-4ab2-9224-09c5be6a4078" />

After:
<img width="628" height="365" alt="image" src="https://github.com/user-attachments/assets/09b5e0f5-2e72-4101-b8cb-b5844fcd7d8a" />
