### PR TITLE
YSH-170: Change Vault KUBERNETES auth config 'jwt' to 'path'

### DIFF
--- a/guide/tutorials/configure-encryption.mdx
+++ b/guide/tutorials/configure-encryption.mdx
@@ -437,11 +437,11 @@ For enhanced security, you can hide the sensitive values using [environment vari
 | **Kubernetes authentication**      |        | Use Kubernetes authentication.                                         |
 | `type`                             | String | **Must be `KUBERNETES`.** Indicates the type of authentication.        |
 | `role`                             | String | Kubernetes role.                                                       |
-| `jwt`                              | String | Kubernetes JWT token.                                                  |
+| `path`                             | String | (Optional) Token file path for the Kubernetes auth method.             |
 | _**Managed identity**_             |        | Load authentication information from the below environment variables.  |
 | `VAULT_AUTH_TYPE`                  | String | **Must be `KUBERNETES`.** Indicates the type of authentication.        |
 | `VAULT_KUBERNETES_ROLE`            |        | Kubernetes role.                                                       |
-| `VAULT_KUBERNETES_JWT`             |        | Kubernetes JWT token.                                                  |
+| `VAULT_KUBERNETES_PATH`            |        | (Optional) Token file path for the Kubernetes auth method.             |
 | **GCP authentication**             |        | Use Google Cloud Platform authentication.                              |
 | `type`                             | String | **Must be `GCP`.** Indicates the type of authentication.               |
 | `role`                             | String | GCP role for authentication.                                           |

--- a/snippets/changelog/Gateway-3.12.0.mdx
+++ b/snippets/changelog/Gateway-3.12.0.mdx
@@ -23,6 +23,12 @@ The old */health* API is now deprecated but it will continue to function.
 Please update your configuration to use the new liveness and readiness probe endpoints.
 </Warning>
 
+#### Configuration key change for Vault KUBERNETES authentication type
+
+[Vault KUBERNETES authentication type](https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth/methods/kubernetes#token_path) has been corrected to read the token from a file in the running pod.
+
+Because of this, KUBERNETES authentication's configuration key `jwt` (`VAULT_KUBERNETES_JWT`) is changed to `path` (`VAULT_KUBERNETES_PATH`). This optional configuration contains the path of the file containing the token. It defaults to `/var/run/secrets/kubernetes.io/serviceaccount/token` following the Vault documentation.
+
 ### New features
 
 #### New `GATEWAY_AUDIT_LOG_EVENT_TYPES` environment variable


### PR DESCRIPTION
Code PR: https://github.com/conduktor/conduktor-proxy/pull/2673
Linear ticket: https://linear.app/conduktor/issue/YSH-170/change-documentation-on-kubernetes-auth-support-for-vault