### PR TITLE
Improve sni routing tls termination section

### DIFF
--- a/guide/tutorials/sni-routing.mdx
+++ b/guide/tutorials/sni-routing.mdx
@@ -52,15 +52,15 @@ To configure the port that is returned in the metadata, you can use the `GATEWAY
 
 ### 2. TLS termination
 
-If Gateway is supposed to act as an SNI router, it must terminate (i.e., decrypt) the incoming TLS connections. Reasons:
+When Gateway is set up to act as the SNI router, it has to terminate (i.e., decrypt) the incoming TLS connections because:
 
-1. **SNI information requires TLS handling**: The SNI information is transmitted in the TLS ClientHello handshake. To forward network requests based on TLS SNI, Gateway must participate in the TLS handshake to extract the server name indication. If TLS is terminated upstream of Gateway, the SNI information is no longer available.
+1. **SNI information requires TLS handling**: this information is transmitted in the TLS `ClientHello` handshake. To forward network requests based on TLS SNI, Gateway has to participate in the TLS handshake to extract the server name indication. If TLS is terminated upstream of Gateway, the SNI information is no longer available.
 
-2. **Kafka protocol inspection requires decryption**: Even though SNI information is available in the unencrypted portion of the TLS handshake, Gateway must decrypt the traffic to apply its functionality, which operates on the Kafka protocol layer. Since Gateway needs to inspect, modify, or route based on Kafka protocol messages (API keys, topics, etc.), TLS passthrough is not possible.
+2. **Kafka protocol inspection requires decryption**: even though SNI information is available in the un-encrypted portion of the TLS handshake, Gateway has to decrypt the traffic to apply its functionality, which operates on the Kafka protocol layer. Since Gateway needs to inspect, modify or route based on Kafka protocol messages (API keys, topics, etc.), TLS passthrough is not possible.
 
-Gateway must therefore
-- handle the TLS handshake with the client and
-- have a valid keystore certificate for the advertised host (and all the brokers in the cluster)
+Therefore, Gateway has to both:
+- handle the TLS handshake with the client and 
+- have a valid keystore certificate for the advertised host (and all the brokers in the cluster).
 
 ### 3. Prepare Gateway's keystore certificate
 

--- a/guide/tutorials/sni-routing.mdx
+++ b/guide/tutorials/sni-routing.mdx
@@ -52,12 +52,11 @@ To configure the port that is returned in the metadata, you can use the `GATEWAY
 
 ### 2. TLS termination
 
-The concept of SNI routing isn't specific to Gateway. It relies on information inside the TLS connection for the SNI router to determine how to forward network requests. To be able to access this information, the SNI router must terminate the TLS connection.
+If Gateway is supposed to act as an SNI router, it must terminate (i.e., decrypt) the incoming TLS connections. Reasons:
 
-In our case, as Gateway acts as SNI router, it has to:
+1. **SNI information requires TLS handling**: The SNI information is transmitted in the TLS ClientHello handshake. To forward network requests based on TLS SNI, Gateway must participate in the TLS handshake to extract the server name indication. If TLS is terminated upstream of Gateway, the SNI information is no longer available.
 
-- handle the TLS handshake with the client and
-- have a valid keystore certificate for the advertised host (and all the brokers in the cluster)
+2. **Kafka protocol inspection requires decryption**: Even though SNI information is available in the unencrypted portion of the TLS handshake, Gateway must decrypt the traffic to apply its functionality, which operates on the Kafka protocol layer. Since Gateway needs to inspect, modify, or route based on Kafka protocol messages (API keys, topics, etc.), TLS passthrough is not possible.
 
 ### 3. Prepare Gateway's keystore certificate
 

--- a/guide/tutorials/sni-routing.mdx
+++ b/guide/tutorials/sni-routing.mdx
@@ -58,6 +58,10 @@ If Gateway is supposed to act as an SNI router, it must terminate (i.e., decrypt
 
 2. **Kafka protocol inspection requires decryption**: Even though SNI information is available in the unencrypted portion of the TLS handshake, Gateway must decrypt the traffic to apply its functionality, which operates on the Kafka protocol layer. Since Gateway needs to inspect, modify, or route based on Kafka protocol messages (API keys, topics, etc.), TLS passthrough is not possible.
 
+Gateway must therefore
+- handle the TLS handshake with the client and
+- have a valid keystore certificate for the advertised host (and all the brokers in the cluster)
+
 ### 3. Prepare Gateway's keystore certificate
 
 The keystore certificate for Gateway with SNI routing needs to include **the Gateway advertised host, as well as a SAN for each advertised broker in the cluster**.


### PR DESCRIPTION
Improve SNI routing -> TLS termination: section should not state that due to the protocol design gateway must terminate TLS in order to route based no SNI IMO. The fact that gw must decrypt is not SNI related.