### PR TITLE
Claude generated fix for Alert migration to Callout syntax

### DIFF
--- a/desktop/account-management/managing-permissions-rbac.mdx
+++ b/desktop/account-management/managing-permissions-rbac.mdx
@@ -7,9 +7,9 @@ description: Allow/Deny access to specific features of Conduktor Desktop for sen
 
 # Managing Permissions / RBAC
 
-:::info
+<Info>
 This feature is available only for Enterprises.
-:::
+</Info>
 
 To be in control of what features your users can use on your clusters when using Conduktor Desktop, considering limiting their permissions. This is available on your account at [https://account.conduktor.io](https://account.conduktor.io).
 
@@ -35,10 +35,10 @@ You want to ensure that all your users cannot write into your production cluster
 
 ![](../assets/cdk-add-cluster.png)
 
-:::tip
+<Tip>
 A cluster ID uniquely identifies your clusters. It is a unique identifier assigned automatically
 to an Apache Kafka cluster.
-:::
+</Tip>
 
 ## How to setup the permissions of a cluster?
 
@@ -48,11 +48,11 @@ By default, there is any restriction on what your users can do on your clusters.
 
 ![](../assets/cdk-default-rbac.png)
 
-:::tip
+<Tip>
 You can enable access control and choose the base role _Viewer_ to set predefined permissions to
 prevent any modifications to your cluster by your users (eg: disallowing producing to topics,
 broker config modifications, topic creation/deletion, altering schemas in schema registry, ...)
-:::
+</Tip>
 
 ### How to set a role for specific groups or users?
 
@@ -60,11 +60,11 @@ You can provide different permissions set for your users by assigning them diffe
 
 ![](../assets/cdk-cluster-rbac.png)
 
-:::caution
+<Warning>
 The effective permissions of a user is the total of his permissions and all permissions of groups he belongs to.
 
 The base role will give its permissions access to every users of the subscription. You can't give less access right for a single user. We advise you to not give a too powerful base role on your cluster.
-:::
+</Warning>
 
 ### Could I define my own role?
 
@@ -90,11 +90,11 @@ Then click on **Add permission group** to select the members and the permissions
 
 ![](../assets/cdk-topic-rbac.png)
 
-:::info
+<Info>
 The permissions assigned to an user are loaded when he connects to the cluster with Conduktor
 Desktop. Already connected users won't have their permissions changed until they disconnect then
 reconnect to the cluster.
-:::
+</Info>
 
 ## How does this affect Conduktor Desktop?
 
@@ -106,10 +106,10 @@ For instance, if we disabled "Produce Into Topics" on a cluster, users connected
 
 ![Same view with all permissions enabled](../assets/capture-decran-du-2021-08-26-17-42-03.png)
 
-:::info
+<Info>
 Removing the specific permission **_Allow Users to Connect_** will entirely prevent
 the connection to the cluster.
-:::
+</Info>
 
 ## Additional Remarks
 

--- a/desktop/conduktor-first-steps/install/linux.mdx
+++ b/desktop/conduktor-first-steps/install/linux.mdx
@@ -12,8 +12,9 @@ We have prepared three distributions for Conduktor
 
 ## How to install Conduktor on Ubuntu/Debian
 
-:::caution For Ubuntu 16 or 20, read the warnings below. 
-:::
+<Warning>
+For Ubuntu 16 or 20, read the warnings below. 
+</Warning>
 
 You can use a `.deb` file to install Conduktor on your Ubuntu/Debian. Download the .deb from our download page, then you can install Conduktor using the following command:
 

--- a/desktop/conduktor-first-steps/licenses-and-activations/offline-licenses.mdx
+++ b/desktop/conduktor-first-steps/licenses-and-activations/offline-licenses.mdx
@@ -8,10 +8,10 @@ description: For companies without online access, offline licenses are the way t
 
 Conduktor relies on [Auth0](/desktop/miscellaneous/data-security) to manage user authentication securely and check our software licenses. Therefore, it is not _normally_ possible to use Conduktor if you don't have an online access. This was limitating for secured enterprises where online is just not possible (insurance, banking institutions etc.). This is why we developed an offline mode.
 
-:::tip
+<Tip>
 Make sure to purchase the **Offline option** with your subscription to use this
 feature.
-:::
+</Tip>
 
 ## Process to login offline
 

--- a/desktop/conduktor-first-steps/login-troubleshooting/certificates-faq.mdx
+++ b/desktop/conduktor-first-steps/login-troubleshooting/certificates-faq.mdx
@@ -85,10 +85,10 @@ If you are using Windows and Mac, and your organization has pushed certificates 
 
 This means that you don't need to define the trust store for each individual component anymore.&#x20;
 
-:::warning
+<Warning>
 Unfortunately, we were not able to integrate **ksqlDB** in our new certificate model
 yet.
-:::
+</Warning>
 
 We remain fully compatible with the previous methods so if you have configured your Kafka clusters with .jks files, or if you still want to use this mechanism, everything will work as usual.
 
@@ -117,9 +117,9 @@ ssl.key.password=test1234
 
 #### Inline Access Key and Access Certificate
 
-:::caution
+<Warning>
 Please note the trailing `\` at the end of each line which signals a multiline content
-:::
+</Warning>
 
 ```
 ssl.keystore.type=PEM

--- a/desktop/conduktor-first-steps/login-troubleshooting/index.mdx
+++ b/desktop/conduktor-first-steps/login-troubleshooting/index.mdx
@@ -43,11 +43,11 @@ This can happen due to many reasons. Here are a few:
 - Ensure you don't have an **antivirus** or a **firewall** blocking communications. You may have to add `https://auth.conduktor.io` to some allow-list or something.
 - By default, Conduktor uses your system proxy. This can causes some troubles such as: `Unable to tunnel through proxy. Proxy returns` Go to the settings, setup your proxy manually instead of the system proxy and and add an exception for `*.conduktor.io`
 
-:::info
+<Info>
 The JVM embedded in Conduktor (Java 13+, if you are using the classic installation process) trusts
 **Let's Encrypt's CA**, which is the one that emits the https certificate of our authentication
 server `https://auth.conduktor.io` so nothing specific to setup here.
-:::
+</Info>
 
 ## Other misc errors
 

--- a/desktop/conduktor-first-steps/login-troubleshooting/internet-proxy.mdx
+++ b/desktop/conduktor-first-steps/login-troubleshooting/internet-proxy.mdx
@@ -24,6 +24,6 @@ From there, you can set the proxy manually and enter:
 - password
 - a list of domains the proxy should not be used on
 
-:::tip
+<Tip>
 After changing the proxy settings, please restart Conduktor
-:::
+</Tip>

--- a/desktop/conduktor-first-steps/sign-in/index.mdx
+++ b/desktop/conduktor-first-steps/sign-in/index.mdx
@@ -8,10 +8,10 @@ description: Getting started with the sign-in process
 
 In order for us to verify the license you have purchased, we require you to sign in to Conduktor. For this, we are using Auth0 for user management.&#x20;
 
-:::info
+<Info>
 Do you have an internet proxy? Check out the
 [internet proxy section](/desktop/conduktor-first-steps/login-troubleshooting/internet-proxy).
-:::
+</Info>
 
 ## Login flow
 

--- a/desktop/conduktor-first-steps/sign-in/single-sign-on.mdx
+++ b/desktop/conduktor-first-steps/sign-in/single-sign-on.mdx
@@ -66,11 +66,11 @@ There are two important fields you need to declare your Application:
 
 #### Required claims
 
-:::warning
+<Warning>
 Due to some limitation on Auth0, we need that your SAML assertion contains custom claims. Check your IdP documentation to on how to do this.
 
 Okta documentation: [Configure SAML attributes](https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement?language=en_US)
-:::
+</Warning>
 
 - `email_verified` with the value `true`.&#x20;
 - `email` must be present and **lowercase**
@@ -93,11 +93,11 @@ Leave most default as-is except for the "Sign-in redirect URL": `https://auth.co
 
 #### Required claims
 
-:::warning
+<Warning>
 Due to some limitation on Auth0, we need that your OIDC token contains custom claims. Check your IdP documentation to on how to do this.
 
 Okta documentation: [Configure OIDC attributes](https://developer.okta.com/docs/guides/customize-tokens-returned-from-okta/main)
-:::
+</Warning>
 
 - `email_verified` with the value `true`.&#x20;
 - `email` must be present and **lowercase**

--- a/desktop/features/brokers-management.mdx
+++ b/desktop/features/brokers-management.mdx
@@ -6,9 +6,9 @@ description: You can modify non read-only configurations dynamically in the Brok
 
 # Brokers Management
 
-:::info
+<Info>
 Work In Progress
-:::
+</Info>
 
 ## Listing
 
@@ -32,11 +32,11 @@ Readonly properties have a lock icon, and sensitive properties (value hidden) ha
 
 ![](../assets/broker-details.png)
 
-:::caution
+<Warning>
 Kafka versions before 2.4.x do not support the Incremental Alter Config API. Because of that,
 dynamically-set sensitive configurations will be lost when updating another configuration on the
 same broker. Proceed with caution (Conduktor will warn you if there is a risk)
-:::
+</Warning>
 
 Hover over an editable value to find the pencil icon. It will open the dynamic configuration dialog, that will let you set a new value for this property .
 

--- a/desktop/features/consumer-groups-management.mdx
+++ b/desktop/features/consumer-groups-management.mdx
@@ -97,8 +97,8 @@ There are two ways to remove members from a consumer group:
 - Remove all members at once with the `Remove All Members And Rebalance` button.
 - Remove a selection of members : select the members and use the `ACTIONS` menu. This is only available for member of type static.
 
-:::tip
+<Tip>
 Designed to be used with the **static group membership feature**, an Apache Kafka Consumer feature. It delays rebalancing operations when a member is temporary gone (pod restart, rolling upgrade..) to prevent useless rebalancing.
 
 BUT now, the consumer group coordinator can take time to realize a static member is gone, so forcing a kick here will help trigger rebalancing as soon as possible, to reassign partitions to other members.
-:::
+</Tip>

--- a/desktop/features/consuming-data/custom-deserializers/aws-glue-schema-registry.mdx
+++ b/desktop/features/consuming-data/custom-deserializers/aws-glue-schema-registry.mdx
@@ -31,11 +31,11 @@ You can further configure your deserializer as described in the Glue documentati
 
 - [https://docs.aws.amazon.com/glue/latest/dg/schema-registry-gs.html#schema-registry-gs-serde])https://docs.aws.amazon.com/glue/latest/dg/schema-registry-gs.html#schema-registry-gs-serde
 - [https://github.com/awslabs/aws-glue-schema-registry](https://github.com/awslabs/aws-glue-schema-registry)
-  :::
+</Tip>
 
-</Tip>caution
+<Warning>
 The Glue library doesn't pick the AWS profile from the Kafka config
 **sasl.jaas.config**. If you need to use a different profile than the
 **default**, you must set the following environment variable:
 **AWS_PROFILE="your-profile"**
-:::
+</Warning>

--- a/desktop/features/consuming-data/custom-deserializers/aws-glue-schema-registry.mdx
+++ b/desktop/features/consuming-data/custom-deserializers/aws-glue-schema-registry.mdx
@@ -6,10 +6,10 @@ description: Using Glue Schema with Conduktor Desktop
 
 # AWS Glue Schema Registry
 
-:::info
+<Info>
 This method is temporary as we plan to integrate with the AWS Glue Registry Serdes directly in
 Conduktor soon.
-:::
+</Info>
 
 In order to successfully consume messages serialized with AWS Glue Registry, you first need to repackage the Glue deserializers into a single jar with all its dependencies. Here we'll use <a href="https://get-coursier.io/docs/cli-bootstrap#assemblies" target="_blank">Coursier</a> but feel free to use maven plugins if you prefer.
 
@@ -26,14 +26,14 @@ region=us-west-2
 avroRecordType=GENERIC_RECORD
 ```
 
-:::tip
+<Tip>
 You can further configure your deserializer as described in the Glue documentation:
 
 - [https://docs.aws.amazon.com/glue/latest/dg/schema-registry-gs.html#schema-registry-gs-serde])https://docs.aws.amazon.com/glue/latest/dg/schema-registry-gs.html#schema-registry-gs-serde
 - [https://github.com/awslabs/aws-glue-schema-registry](https://github.com/awslabs/aws-glue-schema-registry)
   :::
 
-:::caution
+</Tip>caution
 The Glue library doesn't pick the AWS profile from the Kafka config
 **sasl.jaas.config**. If you need to use a different profile than the
 **default**, you must set the following environment variable:

--- a/desktop/features/consuming-data/custom-deserializers/redhat-apicurio-schema-registry.mdx
+++ b/desktop/features/consuming-data/custom-deserializers/redhat-apicurio-schema-registry.mdx
@@ -6,10 +6,10 @@ description: Using Apicurio with Conduktor
 
 # RedHat Apicurio Schema Registry
 
-:::info
+<Info>
 This method is temporary as we plan to integrate with the Apicurio Serdes directly in Conduktor
 soon.
-:::
+</Info>
 
 In order to successfully consume messages serialized with RedHat Apicurio Schema Registry, you first need to repackage the Apicurio deserializers into a single jar with all its dependencies. Here we'll use [Coursier](https://get-coursier.io/docs/cli-bootstrap#assemblies) but feel free to use maven plugins if you prefer.&#x20;
 
@@ -28,6 +28,6 @@ apicurio.auth.username=srvc-acct-a95c41e8-xxxx-4e99-xxxx-217755ad7046
 apicurio.auth.password=7d94b05a-xxxx-4f70-xxxx-1e6aba25a8b4
 ```
 
-:::info
+<Info>
 You can further configure your deserializer as described in the Apicurio documentation: [https://www.apicur.io/registry/docs/apicurio-registry/2.2.x/getting-started/assembly-using-kafka-client-serdes.html#registry-serdes-config-consumer_registry](https://www.apicur.io/registry/docs/apicurio-registry/2.2.x/getting-started/assembly-using-kafka-client-serdes.html#registry-serdes-config-consumer_registry)
-:::
+</Info>

--- a/desktop/features/consuming-data/filtering-and-projecting-data.mdx
+++ b/desktop/features/consuming-data/filtering-and-projecting-data.mdx
@@ -53,8 +53,9 @@ If your jq filter is invalid, or only fails for some records, Conduktor will dis
 
 ![](../../assets/screenshot-2020-06-25-at-17.25.48.png)
 
-:::info If you're using Avro, it's also possible to provide a custom schema \(with less fields\) by using the format "Avro \(Custom Schema\)", see [Avro without Confluent?](/desktop/features/consuming-data/) 
-:::
+<Info>
+If you're using Avro, it's also possible to provide a custom schema \(with less fields\) by using the format "Avro \(Custom Schema\)", see [Avro without Confluent?](/desktop/features/consuming-data/)
+</Info>
 
 ## Filtering data
 
@@ -62,8 +63,9 @@ It's possible to combine multiple filters on multiple dimensions: time, quantity
 
 #### Choose where to start from
 
-:::caution By default, Conduktor uses **"now \(latest\)"**: it means that only new incoming data will appear in Conduktor, not the past.
-:::
+<Warning>
+By default, Conduktor uses **"now \(latest\)"**: it means that only new incoming data will appear in Conduktor, not the past.
+</Warning>
 
 - time based: a hour, a date
 - offset based:
@@ -96,8 +98,9 @@ We offer many ways to select only the interesting key/value you're looking for.
 
 Most works with key, value and headers.
 
-:::info If you set several filters, it's treated like an **"AND"**. We **don't** support **"OR"** operand; we don't have any complex UI to tell "\(this or \(that and that\)\) or this" 
-:::
+<Info>
+If you set several filters, it's treated like an **"AND"**. We **don't** support **"OR"** operand; we don't have any complex UI to tell "\(this or \(that and that\)\) or this"
+</Info>
 
 ![](../../assets/screenshot-2020-06-25-at-18.07.45.png)
 
@@ -114,17 +117,19 @@ Not familiar with regexes? Let's present a few use-case to understand their powe
   - `london|paris`: this will match values containing either london or paris
   - `[wz]` it's the "same" but for single characters only \('w' or 'z'\)
 
-:::warning Beware of **"special"** characters like **"(" "{'{'}"** or **"."**, they need to be **"escaped"**.
+<Warning>
+Beware of **"special"** characters like **"(" "{'{'}"** or **"."**, they need to be **"escaped"**.
 
-If you want to match **"1.2.2"** or **"1.2.3"**, use **"1\.2\.[23]"** and NOT **"1.2.[23]"** or you will match **"**1**0**2**4**3**": "."** means **"any character"** 
-:::
+If you want to match **"1.2.2"** or **"1.2.3"**, use **"1\.2\.[23]"** and NOT **"1.2.[23]"** or you will match **"**1**0**2**4**3**": "."** means **"any character"**
+</Warning>
 
-:::info You can use regex with a json-ish syntax if you want to match the json payload, and not use the Json Field filter.
+<Info>
+You can use regex with a json-ish syntax if you want to match the json payload, and not use the Json Field filter.
 
 - "state"\s:\s{'{'}\s"id"\s:\s".",\s"version"\s:\s\*227`
 
-This is the "equivalent" of the json field filter: `.state.version = 227` 
-:::
+This is the "equivalent" of the json field filter: `.state.version = 227`
+</Info>
 
 ### Filter: Json Field
 

--- a/desktop/features/consuming-data/index.mdx
+++ b/desktop/features/consuming-data/index.mdx
@@ -20,9 +20,9 @@ description: >-
 
 ## _How_ Conduktor consumes data
 
-:::tip
+<Tip>
 Conduktor always displays data **chronologically**.
-:::
+</Tip>
 
 Kafka only provides ordering within a single partition, not across partitions. Because it does not make sense to consume data non-chronologically in Conduktor, we've added our own optimization to always render the data in a deterministic way (chronologically) while preserving memory and CPU. This also works for multi-topics consumption (see below).
 
@@ -42,10 +42,10 @@ We provide 2 views when consuming data: simple list and a tabular view. It's pos
 
 You can double-click on a record to open a new dialog with all its info, its schema if it's Avro and so on. You can also open several of them at once to compare records.
 
-:::tip
+<Tip>
 Pick "JSON" as your Value deserializer to see the **formatted JSON** in the details
 dialog. If you pick just "string", it won't be formatted otherwise.
-:::
+</Tip>
 
 ![The payload of a record](../../assets/screenshot-2020-06-25-at-15.15.11.png)
 
@@ -80,9 +80,9 @@ This will open a panel updated in real-time displaying the progress for all part
 
 ![](<../../assets/screenshot-2020-06-25-at-16.48.45 (1).png>)
 
-:::caution
+<Warning>
 It's possible to identify if a partition has issues if it's not moving on or barely (probably that
 the leader broker of this partitions is in trouble)
-:::
+</Warning>
 
 You know when a partition is totally consumed when it goes green. If some applications produces at the same-time, Conduktor automatically updates itself (the end offsets) and you may see partitions blinking between blue and green (Conduktor consuming at the same rate than the producers).

--- a/desktop/features/consuming-data/pick-your-format-wisely.mdx
+++ b/desktop/features/consuming-data/pick-your-format-wisely.mdx
@@ -6,8 +6,9 @@ description: Conduktor supports many formats and growing. From the basic formats
 
 # Pick your format wisely
 
-:::info This is the first thing to setup when you're consuming a topic. 
-:::
+<Info>
+This is the first thing to setup when you're consuming a topic.
+</Info>
 
 Conduktor supports many formats when deserializing data and we keep adding some.
 
@@ -25,11 +26,13 @@ There are 2 formats to pick: the key format and the value format.
 
 ![List of supported value formats](../../assets/value_formats.png)
 
-:::info Conduktor automatically pick "Avro (Auto)" when it detects a matching Confluent Schema Registry subject (if configured) 
-:::
+<Info>
+Conduktor automatically pick "Avro (Auto)" when it detects a matching Confluent Schema Registry subject (if configured)
+</Info>
 
-:::caution If you don't see "Avro (Auto)", it means you didn't configured the url of your schema registry in your cluster configuration: [check the doc](/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/#schema-registry). 
-:::
+<Warning>
+If you don't see "Avro (Auto)", it means you didn't configured the url of your schema registry in your cluster configuration: [check the doc](/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/#schema-registry).
+</Warning>
 
 ## Without Confluent Schema Registry ?
 
@@ -55,8 +58,9 @@ For instance, I want to provide an Avro Schema to read my data:
   - In most cases, this will NOT be checked if we're using this feature
 - The data will be read using this schema!
 
-:::tip It can be used to "project" the data: read and display only a subset of fields 
-:::
+<Tip>
+It can be used to "project" the data: read and display only a subset of fields
+</Tip>
 
 ```javascript
 {
@@ -100,8 +104,9 @@ message SearchRequest {
 
 ![Consume using custom Protobuf Schema](<../../assets/image (54) (1).png>)
 
-:::info Conduktor will iterate over all root message types in the provided schema and select the best one for each message (the first type decoding without missing or unknown fields). 
-:::
+<Info>
+Conduktor will iterate over all root message types in the provided schema and select the best one for each message (the first type decoding without missing or unknown fields).
+</Info>
 
 ### Using AWS Glue Registry
 
@@ -121,8 +126,9 @@ If you try to consume Avro data without properly configuring it (and because it 
 
 On the contrary, if you try to read non-Avro data using the Avro format, you'll end up with a list of errors (Conduktor doesn't stop, in case it was test records for instance):
 
-:::warning ERR: Unknown magic byte! 
-:::
+<Warning>
+ERR: Unknown magic byte!
+</Warning>
 
 ![](<../../assets/screenshot-2020-06-25-at-16.15.21 (1).png>)
 

--- a/desktop/features/kafka-access-control-list-acl/index.mdx
+++ b/desktop/features/kafka-access-control-list-acl/index.mdx
@@ -24,9 +24,9 @@ Conduktor "Security" tab lets you see the current ACLs of your Kafka cluster, an
 
 Kafka's ACLs are quite "atomic", there are many ACLs possible. Generally, you must combine them to be able to provide a producer / a consumer / a kafka streams application, enough ACLs to make it work properly.
 
-:::info
+<Info>
 Documentation about ACLs: [https://docs.confluent.io/current/kafka/authorization.html](https://docs.confluent.io/current/kafka/authorization.html)
-:::
+</Info>
 
 Conduktor helps you by providing a simple wizard.
 

--- a/desktop/features/ksqldb/how-to-query-with-ksqldb.mdx
+++ b/desktop/features/ksqldb/how-to-query-with-ksqldb.mdx
@@ -10,9 +10,9 @@ description: Do you prefer Pushing or Pulling?
 
 You can create streams or tables using a simple KSQL editor. You can have many queries, just add empty lines between each queries, for them to be considered independent. They will be execute one by one in different statements.
 
-:::warning
+<Warning>
 It's for KSQL stream queries, not metadata queries like "SHOW STREAMS;".
-:::
+</Warning>
 
 ![](../../assets/screenshot-2021-02-02-at-22.44.48.png)
 

--- a/desktop/features/monitoring.mdx
+++ b/desktop/features/monitoring.mdx
@@ -27,9 +27,9 @@ In your Cluster Configuration, you can enable either JMX or Jolokia access for C
 
 JMX is a common protocol used in Java applications to expose metrics. Apache Kafka is a Java application, and exposes naturally tons of JMX metrics.
 
-:::caution
+<Warning>
 JMX is not an HTTP protocol, it cannot be accessed through an Internet browser
-:::
+</Warning>
 
 ![](../assets/2021-02-03-14-04-03-metrics.png)
 
@@ -79,10 +79,10 @@ Jolokia is a technology to expose a HTTP server to access JMX metrics over a sim
 
 It's often started as a Java agent directly on the main Java program. When Jolokia starts, it starts an HTTP server on a configurable port (default: 8778).
 
-:::info
+<Info>
 This is the power of Jolokia. Because it exposes the metrics through HTTP, they are accessible
 through an Internet browser
-:::
+</Info>
 
 ![](../assets/screenshot-2021-01-17-at-21.56.35.png)
 

--- a/desktop/features/producing-data/index.mdx
+++ b/desktop/features/producing-data/index.mdx
@@ -59,10 +59,10 @@ Apache Avro has special types that does not exist in plain JSON, such as "bytes"
 
 Conduktor Desktop supports Apache Avro 1.9.0 specification: [https://avro.apache.org/docs/1.9.0/spec.html#Logical+Types](https://avro.apache.org/docs/1.9.0/spec.html#Logical+Types)
 
-:::tip
+<Tip>
 Conduktor Desktop is made for **humans**, therefore we handle human-friendly
 representations of such complex types when consuming and when producing data to Avro topics.
-:::
+</Tip>
 
 When producing data from Conduktor Desktop, the format must be in JSON. When sending the data, Conduktor translates the JSON payload to an Apache Avro format. Most types are simple and exist in JSON and Apache Avro (like integers, strings) but some needs a special handling by Conduktor to be "understood" and properly converted.
 
@@ -132,10 +132,10 @@ Conduktor has a notion of "template" to save & reuse what you're producing to yo
 
 You can create as many template as you want, and duplicate them to easily create them from existing ones. It's also possible to create a template from a consumed message!
 
-:::warning
+<Warning>
 Do not forget to click "SAVE" on the bottom right of the dialog to save your modification,
 otherwise you'll lose them.
-:::
+</Warning>
 
 ![a copy was created](../../assets/screenshot-2020-07-24-at-11.40.05.png)
 

--- a/desktop/features/schema-registry-management/avro-tools.mdx
+++ b/desktop/features/schema-registry-management/avro-tools.mdx
@@ -38,9 +38,9 @@ For instance, here, if we remove a field, we know it's not FORWARD nor FULL comp
 
 Often you start from a Subject, no need to copy the original schema in the left part. Go to the Subject and click on "Check Compatibility", the dialog will display the latest version of the Subject, but will also have all the schemas lineage in memory, to be used in the Transitive checks.
 
-:::info
+<Info>
 The transitive checks are useful only when you are comparing a **lineage** of
 schemas.
-:::
+</Info>
 
 ![](../../assets/screenshot-2020-09-20-at-19.33.50.png)

--- a/desktop/features/schema-registry-management/schema-compatibilities.mdx
+++ b/desktop/features/schema-registry-management/schema-compatibilities.mdx
@@ -12,10 +12,10 @@ description: Defining the compatibility of your subjects ensure that your consum
 
 Long story short, there are 7 modes of compatibility handled by the Schema Registry:
 
-:::tip
+<Tip>
 **Transitive** means the whole lineage of schemas is verified. Not transitive means
 only the last 2 schemas are verified.
-:::
+</Tip>
 
 - **Full + Transitive**: The safest, recommended.
   - Add/Delete optional fields only.

--- a/desktop/features/topics-management/smart-groups.mdx
+++ b/desktop/features/topics-management/smart-groups.mdx
@@ -8,10 +8,10 @@ description: Smart Groups is a feature to remove the strain due to long names of
 
 # Smart Groups
 
-:::caution
+<Warning>
 This is an advanced feature due to the usage of regular expressions. This provides a poor
 readability and non-technical people should be assisted in order to use it.
-:::
+</Warning>
 
 ## Simplify topics or subjects name
 
@@ -28,10 +28,10 @@ This will open a configuration dialog where the magic will be configured, throug
 - We setup regular expressions \(as many as we want\)
 - We pick one group to be the name of the entity in the listing \(instead of the long name\)
 
-:::info
+<Info>
 To create columns from parts, we must use **Named Capturing Groups**.
 [https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html)
-:::
+</Info>
 
 The following is a capturing group named "environment" matching multiple characters.
 
@@ -61,7 +61,7 @@ The result is a screen way more readable, by removing useless information and di
 
 ![](../../assets/screenshot-2020-05-01-at-01.43.05.png)
 
-:::info
+<Info>
 The usage of regular expressions is necessary but we may provide a wizard later to simplify this
 step. Don't hesitate to [contact us](https://www.conduktor.io/contact) if that matters to you.
-:::
+</Info>

--- a/desktop/features/topics-management/topic-details.mdx
+++ b/desktop/features/topics-management/topic-details.mdx
@@ -17,10 +17,10 @@ When you go to the details of a topic, we present a summary with many of the mos
   - **Count** is the sum (end offsets - beginning offsets) for all partitions (the beginning offsets are moving forward due to limited topic retention time/size).
   - **Overall** is the sum of all end offsets for all partitions. It means that as least this many records have been published to this topic since its creation.
 
-:::caution
+<Warning>
 If the topic is **compacted**, it barely means something because the partitions have many "holes" in them (Conduktor warns you about that in this case).
 Even without compaction, Count doesn't mean that you have published this number of records in your topic if you are using **transactions** (because you would have transaction markers hidden in there, and even aborted transactions with their "aborted" data..)
-:::
+</Warning>
 
 - **Partitions** / All have a leader
 - **Replication Factor** / All ISRs at N
@@ -54,10 +54,10 @@ This is useful to understand how the partitions are distributed in your cluster.
 
 ![](../../assets/screenshot-2020-09-19-at-22.26.41.png)
 
-:::caution
+<Warning>
 Also, if some partitions are in trouble, you can go to this screen and see at a glance if they all
 belong to the same broker.
-:::
+</Warning>
 
 ## How to update the configuration of a Topic?
 
@@ -74,10 +74,10 @@ Go to the Configuration tab on the topic:
 
 ![](../../assets/screenshot-2020-09-20-at-21.57.51.png)
 
-:::warning
+<Warning>
 It's possible you do not have access to the configuration of a Topic because your Kafka user does
 not have the necessary ACLs configured.
-:::
+</Warning>
 
 You'll see all the properties of your topic. Even if you didn't configured anything, we can see the default that Kafka is using for the topic, and all the custom configuration you did are flag as TOPIC.
 
@@ -93,10 +93,10 @@ For instance, here, we want to increase `min.cleanable.dirty.ratio`, we can hove
 
 ![](../../assets/screenshot-2020-09-20-at-22.00.29.png)
 
-:::tip
+<Tip>
 It's also possible to DELETE an override to fallback on the default value of the cluster. (the
 defaults are configurable by the Kafka clusters administrators)
-:::
+</Tip>
 
 ### Where does the configuration comes from?
 
@@ -118,10 +118,10 @@ Conduktor helps you to know where the config comes from:
 
 ![S stands for Static](../../assets/screenshot-2020-09-20-at-22.05.30.png)
 
-:::tip
+<Tip>
 You may have noticed the toggle button "Show Overrides Only" in this Configuration panel: it's
 used to remove the Kafka defaults and see only what have been modified.
-:::
+</Tip>
 
 ## How to detect if a Topic is in trouble?
 

--- a/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/connect-to-amazon-msk.mdx
+++ b/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/connect-to-amazon-msk.mdx
@@ -12,10 +12,10 @@ Amazon MSK is a self-managed service that makes it easy to build and run applica
 
 It lacks several important Apache Kafka features like Kafka Connect, Kafka Streams, ksqlDB, and is not cloud-native (serverless, like S3 or Kinesis) but is just a provisioned infrastructure
 
-:::info
+<Info>
 AWS MSK supports also Kafka Connect clusters.
 [Read more about it](https://aws.amazon.com/blogs/aws/introducing-amazon-msk-connect-stream-data-to-and-from-your-apache-kafka-clusters-using-managed-connectors).
-:::
+</Info>
 
 ## Conduktor & MSK
 
@@ -52,11 +52,11 @@ The networking layer looks like this (not public):
 
 ### Alternative: Another Proxy
 
-:::warning
+<Warning>
 If you get some errors such as "Exception in upstream channel.:
 java.lang.IllegalArgumentException: Invalid version for API key METADATA: 11", your proxy may be
 incompatible with your version of Apache Kafka.
-:::
+</Warning>
 
 You can try running another proxy: [https://github.com/grepplabs/kafka-proxy](https://github.com/grepplabs/kafka-proxy) It's a bit more complicated to setup but is more configurable.
 

--- a/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/connecting-to-a-secure-kafka.mdx
+++ b/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/connecting-to-a-secure-kafka.mdx
@@ -38,10 +38,10 @@ other.configs=values...
 
 What Conduktor needs to connect to a secure Kafka cluster is all the values from your `config.properties` file.
 
-:::info
+<Info>
 In case you don't know what should be the values in the **config.properties** file, please contact your Kafka administrator.
 **Note:** these are the same properties you would use in your Kafka Java clients or applications.
-:::
+</Info>
 
 ## SSL Configuration
 
@@ -72,10 +72,10 @@ Other configuration settings that may also be needed depending on our requiremen
 4. ssl.truststore.type=JKS
 5. ssl.keystore.type=JKS
 
-:::caution
+<Warning>
 Please make sure to put the **full paths** to your SSL certificates in your
 properties file\ Relative paths may not work for Conduktor.
-:::
+</Warning>
 
 ## SASL Configuration
 
@@ -125,10 +125,10 @@ Would be converted to the following `sasl.jaas.config` property:
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required  username="alice" password="alice-secret";
 ```
 
-:::caution
+<Warning>
 Please make sure to put the **full paths** to your SASL key files in your properties
 file\ Relative paths may not work for Conduktor.
-:::
+</Warning>
 
 ### Example using Kerberos
 

--- a/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/impossible-connection-setups.mdx
+++ b/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/impossible-connection-setups.mdx
@@ -22,8 +22,9 @@ This will typically be a one of these problems:
 - you're using Docker and you did not expose the Kafka ports to your host, where Conduktor is running
 - your computer cannot resolve the IPs/DNS exposed by Apache Kafka because your cluster is running in a private subnet not known to your computer
 
-:::tip Just remember that Conduktor is running on **your** machine, running on **your** network, which may be _different_ from the network your Apache Kafka clusters are running. 
-:::
+<Tip>
+Just remember that Conduktor is running on **your** machine, running on **your** network, which may be _different_ from the network your Apache Kafka clusters are running.
+</Tip>
 
 ## Understanding Kafka Listeners
 

--- a/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/index.mdx
+++ b/desktop/kafka-cluster-connection/setting-up-a-connection-to-kafka/index.mdx
@@ -109,16 +109,16 @@ We current support Jolokia and JMX to extract metrics.
 - **Jolokia:** please provide the protocol as well as the Jolokia port. The [Jolokia agent](https://jolokia.org/agent.html) should be installed on all your Kafka brokers.
 - **JMX:** if you have started the JMX utility on your Kafka brokers, please provide the JMX port for Conduktor to connect to.
 
-:::info
+<Info>
 Please contact us in case you need other metrics mechanisms.
-:::
+</Info>
 
 ### SSH (note: not a connection setting)
 
-:::caution
+<Warning>
 The SSH configuration is quite powerful and should only be allowed to be set-up for your Kafka
 administrators. Average Kafka users should not need to fill up the details of that tab.
-:::
+</Warning>
 
 The SSH configuration enables Conduktor to directly access your brokers machines, enabling features like the rolling restart feature.
 
@@ -184,10 +184,10 @@ To edit the configuration of a cluster, hover your mouse over a cluster, and the
 
 ![the config button appears next to the cluster name](<../../assets/image (17).png>)
 
-:::info
+<Info>
 The ability to export, backup and share Kafka cluster configurations is an upcoming feature of the
 Enterprise License.
-:::
+</Info>
 
 ## Secure Kafka Clusters
 

--- a/desktop/miscellaneous/configuring-conduktor.mdx
+++ b/desktop/miscellaneous/configuring-conduktor.mdx
@@ -10,10 +10,10 @@ description: How to configure Conduktor Desktop
 
 Conduktor comes with many options (and growing) to customize its behaviour. This is important when it comes to large clusters: you don't need everything, so better remove some useless overhead.
 
-:::caution
+<Warning>
 Also, unfortunately, sometimes the clusters are just too big for Conduktor to handle properly,
 making it crash after some time ☹ (improving!)
-:::
+</Warning>
 
 It's also there to configure:
 
@@ -46,9 +46,9 @@ By default, Conduktor is limited to 2GB of memory heap. It's possible to increas
 - Windows: `C:\Program Files\Conduktor\app\Conduktor.cfg`
 - Linux: `/opt/conduktor/lib/app/Conduktor.cfg`
 
-:::warning
+<Warning>
 We do **NOT** recommend to alter this file, **all changes will be lost** when upgrading Conduktor
-:::
+</Warning>
 
 The default options are:
 
@@ -121,7 +121,7 @@ Starting Conduktor 2.7.0, we log everything into a `conduktor.log` file. This ma
 - macOS: `/var/folders/wy/xxx/T/conduktor.log`
   - the path is random. The best way to find it is to look for the kafka.log path (above). conduktor.log sits at the same place
 
-:::tip
+<Tip>
 On Linux and macOS, you can directly start Conduktor from the console to display the logs on
 stdout. (this does not work on Windows, except using alternative unix-ish shells like gitbash)
-:::
+</Tip>

--- a/desktop/miscellaneous/data-security.mdx
+++ b/desktop/miscellaneous/data-security.mdx
@@ -40,11 +40,11 @@ Your Conduktor configuration is stored in a fixed place on your computer:
 - Windows: `C:\Users\<user>\AppData\Local\conduktor\conduktor\`
 - Linux: `/home/<user>/.config/conduktor/` (or XDG Config path if set)
 
-:::caution
+<Warning>
 The folder contains your configuration **app.properties** and its previous version
 **app.properties.bak** that can be used to recover your configuration if something
 happened (and app.properties is broken).
-:::
+</Warning>
 
 ## Where are the logs?
 


### PR DESCRIPTION
- Uses tip in a few places. Possibly not wanted.
- caution -> warning