### PR TITLE
Add changelog for CUS tickets kafka cluster configuration

### DIFF
--- a/snippets/changelog/Console-1.37.0.mdx
+++ b/snippets/changelog/Console-1.37.0.mdx
@@ -29,3 +29,4 @@ You can **patch** (instead of replacing) the YAML configuration. [Find out more 
  - Fixed production rate metrics getting stuck at high values when producer rates drop instantly to zero, which was causing artificially inflated metrics in systems with bursty production patterns
  - Errors preventing users from logging in are now prominently displayed on the login page
  - The Trust Rules and Policies pages are now hidden for users without [Trust](https://conduktor.io/trust) in their license
+ - Kafka Cluster configuration for SSL passwords no longer displays length unless editing the field, and AWS Glue secrets are no longer clear text.


### PR DESCRIPTION
Description for tickets
https://linear.app/conduktor/issue/CUS-588/six-leak-password-length
https://linear.app/conduktor/issue/CUS-536/internal-secret-isnt-hidden

Other configuration was also made more "secret and obfuscated" but I only included the CUS ticket changes in the changelog. Do you suggest I mention it was reported by SIX, so that they notice it more easily @ajross  ?