### PR TITLE
Replace 4 backticks by 3 backticks when needed

### DIFF
--- a/guide/conduktor-concepts/interceptors.mdx
+++ b/guide/conduktor-concepts/interceptors.mdx
@@ -16,7 +16,7 @@ To deploy an Interceptor, you need to prepare its configuration. Here's an examp
 <Tabs>
 <Tab title="CLI">
 
-  ````json
+  ```json
   curl \
     --request PUT \
     --url 'http://localhost:8888/gateway/v2/interceptor' \
@@ -41,12 +41,12 @@ To deploy an Interceptor, you need to prepare its configuration. Here's an examp
       }
     }
   }'
-  ````
+  ```
 
 </Tab>
 <Tab title="API">
 
-````json
+```json
 POST /admin/interceptors/v1/interceptor/enforce-partition-limit
 {
   "pluginClass": "io.conduktor.gateway.interceptor.safeguard.CreateTopicPolicyPlugin",
@@ -60,7 +60,7 @@ POST /admin/interceptors/v1/interceptor/enforce-partition-limit
     }
 }
 }
-````
+```
 
 </Tab>
 </Tabs>
@@ -129,7 +129,7 @@ There are four targeting scopes:
 
 Example:
 
-````json
+```json
 // This interceptor only applies to service account 'sa-clickstream'
 curl \
   --request PUT \
@@ -158,7 +158,7 @@ curl \
     }
   }
 }'
-````
+```
 
 ### Overriding
 

--- a/guide/conduktor-concepts/logical-topics.mdx
+++ b/guide/conduktor-concepts/logical-topics.mdx
@@ -44,7 +44,7 @@ They are completely transparent to consumers and producers and allow you to emul
 
 To create concentrated topics, first deploy `ConcentrationRule`:
 
-````yaml
+```yaml
 ---
 kind: ConcentrationRule
 metadata:
@@ -53,11 +53,11 @@ spec:
   pattern: concentrated.*
   physicalTopics:
     delete: physical.topic
-````
+```
 
 Then topics that match the *ConcentrationRule* `spec.pattern`:
 
-````bash
+```bash
 kafka-topics \
   --bootstrap-server conduktor-gateway:6969 \
   --topic concentrated.topicA \
@@ -67,7 +67,7 @@ kafka-topics \
   --bootstrap-server conduktor-gateway:6969 \
   --topic concentrated.topicB \
   --partitions 4
-````
+```
 
 ![Topic Concentration](/images/concentrated-topic.png)
 
@@ -81,7 +81,7 @@ To ensure that consumers don't consume messages from other partitions or from ot
 
 You can create concentrated topics with any *cleanup.policy*, but your `ConcentrationRule` has to have a backing topic for each of them, otherwise it won't let you create the topic.
 
-````yaml
+```yaml
 ---
 kind: ConcentrationRule
 metadata:
@@ -92,18 +92,18 @@ spec:
     delete: physical.topic-delete
     compact: physical.topic-compact
     # deleteCompact: physical.topic-deletecompact
-````
+```
 
 In this example, since the config for `spec.deleteCompact` is commented out, trying to create this topic will fail:
 
-````bash
+```bash
 kafka-topics --create 
     --bootstrap-server conduktor-gateway:6969 \
     --topic <your-topic-name> \
     --partitions 3 \
     --config cleanup.policy=compact,delete
 Error while executing topic command : Cleanup Policy is invalid
-````
+```
 
 Backing topic cleanup policies are checked when you deploy a new `ConcentrationRule`. This prevents you from declaring a backing topic with a *cleanup.policy* of delete on the *ConcentrationRule* `spec.physicalTopic.compact` field.
 
@@ -143,7 +143,7 @@ When `autoManaged` is enabled:
 - backing topics are automatically created with the default cluster configuration and partition count.
 - concentrated topics created with higher `retention.ms` and `retention.bytes` are allowed. This automatically extends the configuration of the backing topic.
 
-````yaml
+```yaml
 ---
 kind: ConcentrationRule
 metadata:
@@ -153,11 +153,11 @@ spec:
   physicalTopics:
     delete: physical.topic
   autoManaged: true
-````
+```
 
 Let's check the backing topic retention on the physical cluster:
 
-````bash
+```bash
 kafka-configs --bootstrap-server kafka:9092 \
     --entity-type topics --entity-name physical.topic \
     --describe
@@ -165,21 +165,21 @@ Configs for topic 'physical.topic' are:
   cleanup.policy=delete
   retention.ms=604800000
   retention.bytes=-1
-````
+```
 
 Let's try to create a concentrated topic with a higher retention on Gateway:
 
-````bash
+```bash
 kafka-topics --create 
     --bootstrap-server conduktor-gateway:6969 \
     --topic <your-topic-name> \
     --partitions 3 \
     --config retention.ms=704800000
-````
+```
 
 Let's review the backing topic again:
 
-````bash
+```bash
 kafka-configs --bootstrap-server kafka:9092 \
     --entity-type topics --entity-name physical.topic \
     --describe
@@ -187,7 +187,7 @@ Configs for topic 'physical.topic' are:
   cleanup.policy=delete
   retention.ms=704800000
   retention.bytes=-1
-````
+```
 
 As we can see, the retention has been updated.
 
@@ -205,7 +205,7 @@ Any tooling will currently display the message count, and the lag relative to th
 
 To counter this, we've implemented a dedicated offset management capability for `ConcentrationRules`. To enable virtual offsets, add the following line to the `ConcentrationRule`:
 
-````yaml
+```yaml
 ---
 kind: ConcentrationRule
 metadata:
@@ -215,7 +215,7 @@ spec:
   physicalTopics:
     delete: physical.topic
   offsetCorrectness: true
-````
+```
 
 Note that:
 

--- a/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index.mdx
+++ b/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index.mdx
@@ -790,7 +790,7 @@ This prefixing ensures that there's no overlap or conflict between resources bel
 
 In the example below, we assume a topic `order` has been created on Virtual Cluster `vc-alice`. Let's see how other Virtual Clusters and Backing cluster perceive this:
 
-````shell
+```shell
 # Listing topics on Virtual Cluster vc-alice
 $ kafka-topics --bootstrap-server=gateway:6969 --command-config vc-alice.properties --list
 orders
@@ -812,7 +812,7 @@ $ kafka-topics.sh --bootstrap-server=backing-kafka:9092  --list
 vc-alice.orders
 vc-bob.orders
 
-````
+```
 
 ## Configure Gateway for failover
 

--- a/guide/reference/console-reference.mdx
+++ b/guide/reference/console-reference.mdx
@@ -538,7 +538,7 @@ spec:
     user: "admin"
     password: "admin"
     virtualCluster: passthrough
-````
+```
 
 </Tab>
 <Tab title="Terraform">
@@ -681,7 +681,7 @@ resource "conduktor_console_kafka_connect_v2" "connect-1" {
 
 Creates a ksqlDB cluster definition in Console.
 
-````yaml
+```yaml
 ---
 apiVersion: console/v2
 kind: KsqlDBCluster
@@ -696,7 +696,7 @@ spec:
     type: "BasicAuth"
     username: "toto"
     password: "my-secret"
-````
+```
 
 **KafkaConnectCluster checks:**
 
@@ -842,24 +842,24 @@ HTTP security properties are used in KafkaCluster ([schema registry](#confluent-
 
 ### Basic authentication
 
-````yaml
+```yaml
   security:
     type: "BasicAuth"
     username: "toto"
     password: "my-secret"
-````
+```
 
 ### Bearer token
 
-````yaml
+```yaml
   security:
     type: "BearerToken"
     token: "toto"
-````
+```
 
 ### mTLS/client certificate
 
-````yaml
+```yaml
   security:
     type: "SSLAuth"
     key: |
@@ -876,7 +876,7 @@ HTTP security properties are used in KafkaCluster ([schema registry](#confluent-
       8/s+YDKveNdoeQoAmGQpUmxhvJ9rbNYj+4jiaujkfxT/6WtFN8N95r+k3W/1K4hs
       IFyCs+xkcgvHFtBjjel4pnIET0agtbGJbGDEQBNxX+i4MDA=
       -----END CERTIFICATE-----
-````
+```
 
 ## Permissions
 
@@ -894,7 +894,7 @@ A permission applies to a certain `resourceType` which affects the required fiel
 
 ### Topic permissions
 
-````yaml
+```yaml
 # Grants consume, produce and view config to all topics toto-* on shadow-it cluster
 - resourceType: TOPIC
   cluster: shadow-it
@@ -925,7 +925,7 @@ A permission applies to a certain `resourceType` which affects the required fiel
 
 ### Subject permissions
 
-````yaml
+```yaml
 # Grants view and edit compatibility to all subjects starting with sub-* on shadow-it cluster
 - resourceType: SUBJECT
   cluster: shadow-it
@@ -951,7 +951,7 @@ A permission applies to a certain `resourceType` which affects the required fiel
 
 ### ConsumerGroup permissions
 
-````yaml
+```yaml
 # Grants view and reset on all consumer groups starting with group-* on shadow-it cluster
 - resourceType: CONSUMER_GROUP
   cluster: shadow-it

--- a/guide/reference/gateway-reference.mdx
+++ b/guide/reference/gateway-reference.mdx
@@ -11,7 +11,7 @@ These are high-level Gateway object specifications for Conduktor CLI.
 
 Deploys an Interceptor on Gateway.
 
-````yaml
+```yaml
 ---
 apiVersion: gateway/v2
 kind: Interceptor
@@ -30,7 +30,7 @@ spec:
       min: 5
       max: 5
       action: "INFO"
-````
+```
 
 **Interceptor checks:**
 
@@ -70,7 +70,7 @@ The order of precedence from highest (overrides all others) to lowest (most easi
 
 <Tabs>
 <Tab title="CLI">
-````yaml
+```yaml
   ---
   # This interceptor targets everyone (Including Virtual Clusters)
   apiVersion: gateway/v2
@@ -110,7 +110,7 @@ The order of precedence from highest (overrides all others) to lowest (most easi
     scope:
       vCluster: read-only
   spec:
-  ````
+  ```
 </Tab>
 <Tab title="Terraform">
 
@@ -274,7 +274,7 @@ spec:
     - name: admin
     - vCluster: vc-B
       name: "0000-AAAA-BBBB-CCCC"
-````
+```
 
 **GatewayGroup checks:**
 
@@ -305,7 +305,7 @@ spec:
     deleteCompact: titi-cd
   autoManaged: false
   offsetCorrectness: false
-````
+```
 
 **ConcentrationRule checks:**
 

--- a/guide/reference/kafka-reference.mdx
+++ b/guide/reference/kafka-reference.mdx
@@ -10,7 +10,7 @@ Creates a topic in Kafka.
 - **Managed with:** API, CLI, UI, TF
 - **Labels support:** Full
 
-````yaml
+```yaml
 ---
 apiVersion: kafka/v2
 kind: Topic
@@ -32,7 +32,7 @@ spec:
     min.insync.replicas: '2'
     cleanup.policy: delete
     retention.ms: '60000'
-````
+```
 
 **Topic checks:**
 
@@ -195,7 +195,7 @@ Manages the ACLs of a service account in Kafka. This **does not create the servi
 
 Kafka service account example:
 
-````yaml
+```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -234,11 +234,11 @@ spec:
         patternType: PREFIXED
         operations:
           - Read
-````
+```
 
 Aiven service account example:
 
-````yaml
+```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -264,7 +264,7 @@ spec:
       - type: SCHEMA
         name: 'Subject:click.event-stream.avro'
         permission: schema_registry_write
-````
+```
 
 **Service account checks:**
 

--- a/guide/reference/self-service-reference.mdx
+++ b/guide/reference/self-service-reference.mdx
@@ -12,7 +12,7 @@ In Self-service, it's used as a method to organize and re-group multiple deploym
 - **Managed with:** API, CLI, UI
 - **Labels support:** Full
 
-````yaml
+```yaml
 # Application
 ---
 apiVersion: self-service/v1
@@ -23,7 +23,7 @@ spec:
   title: "Clickstream App"
   description: "FreeForm text, probably multiline markdown"
   owner: "groupA" # technical-id of the Conduktor Console Group
-````
+```
 
 **Application checks:**
 
@@ -44,7 +44,7 @@ This is the core concept of Self-service, as it **ties everything together**: Ka
 - **Managed with:** API, CLI, TF
 - **Labels support:** Full
 
-````yaml
+```yaml
 ---
 apiVersion: self-service/v1
 kind: ApplicationInstance
@@ -76,7 +76,7 @@ spec:
       patternType: PREFIXED
       ownershipMode: LIMITED # Topics are still maintained by central team
       name: "legacy-click."
-````
+```
 
 **AppInstance checks:**
 
@@ -119,7 +119,7 @@ Define permissions for the application instance to enable collaboration between 
 - **Managed with:** API, CLI
 - **Labels support:** Missing
 
-````yaml
+```yaml
 # Permission granted to other applications
 ---
 apiVersion: self-service/v1
@@ -136,7 +136,7 @@ spec:
   userPermission: NONE
   serviceAccountPermission: READ
   grantedTo: "another-appinstance-dev"
-````
+```
 
 **Application instance permission checks:**
 
@@ -179,7 +179,7 @@ Creates an application group to directly reflect how your application operates. 
 
 #### Example
 
-````yaml
+```yaml
 # Permissions granted to Console users in the application
 ---
 apiVersion: self-service/v1
@@ -216,7 +216,7 @@ spec:
     - user2@company.org
   externalGroups:
     - GP-COMPANY-CLICKSTREAM-SUPPORT
-````
+```
 
 **Application instance permission checks:**
 
@@ -244,7 +244,7 @@ Instead, the central platform team decides to delegate this responsibility to th
 - **Managed with:** API, CLI
 - **Labels support:** Missing
 
-````yaml
+```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -272,7 +272,7 @@ spec:
         patternType: LITERAL
         operations:
           - Read
-````
+```
 
 **Service account checks:**
 The checks are the same as the [service account](/guide/reference/kafka-reference/#service-account) resource with additional **limitations**:
@@ -343,7 +343,7 @@ spec:
 
 With the two topic policies declared above, the following topic resource would succeed validation:
 
-````yaml
+```yaml
 ---
 apiVersion: kafka/v2
 kind: Topic
@@ -358,7 +358,7 @@ spec:
   configs:
     cleanup.policy: delete
     retention.ms: '60000'        # Checked by Range(60000, 3600000) on `spec.configs.retention.ms`
-````
+```
 
 ### Topic policy constraints
 
@@ -492,7 +492,7 @@ spec.configs.min.insync.replicas:
 
 This object will pass the validation:
 
-````yaml
+```yaml
 ---
 apiVersion: kafka/v2
 kind: Topic
@@ -505,11 +505,11 @@ spec:
   configs:
     cleanup.policy: delete
     retention.ms: '60000'
-````
+```
 
 This object will fail the validation due to a new incorrect definition of `insync.replicas`:
 
-````yaml
+```yaml
 ---
 apiVersion: kafka/v2
 kind: Topic
@@ -523,7 +523,7 @@ spec:
     min.insync.replicas: 3
     cleanup.policy: delete
     retention.ms: '60000'
-````
+```
 
 ## ResourcePolicy
 

--- a/guide/tutorials/self-service-start.mdx
+++ b/guide/tutorials/self-service-start.mdx
@@ -24,9 +24,9 @@ frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media
 
 To follow-along this demo you'll need to clone our repository (repo):
 
-````shell
+```shell
 git clone https://github.com/conduktor/self-service-getting-started
-````
+```
 
 This demo repo contains two directories with each representing a mock repo: `central-team-repo` and `application-team-repo`.
 
@@ -89,34 +89,34 @@ Docker is required to run this demo.
 
 1. Spin up local resources: Conduktor and Kafka. A Docker compose file is provided - simply start it by navigating with your shell to the cloned repo and running the command below (you may need to download the images, if you've not run them before):
 
-    ````bash
+    ```bash
     docker compose up -d
-    ````
+    ```
 
 1. Log into Console at [http://localhost:8080](http://localhost:8080), with the credentials provided in the docker-compose, `admin@conduktor.io` : `adminP4ss!`
 
 1. Generate an admin API key for the Conduktor CLI. Go to **Settings** > **API Keys** > **New API Key** then **copy this value**.
    - Note: This can be done from the CLI by setting the following variables and running the command below, but for this demo we'll be using the UI.
 
-     ````bash
+     ```bash
      # not part of today's demo, shown as an example
      export CDK_USER=admin@conduktor.io 
      export CDK_PASSWORD=adminP4ss!
      conduktor login
      eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzUxMiIsImtp...
-     ````
+     ```
 
 1. Open the `docker-compose.yml` file and assign the value you just copied to the `CDK_API_KEY` environment variable for the `conduktor-ctl` service. Save the file and re-run `docker compose up -d` to create the Conduktor CLI container:
 
-    ````bash
+    ```bash
     docker compose up -d
-    ````
+    ```
 
 1. Open a Conduktor CLI by executing into the container:
 
-    ````bash
+    ```bash
     docker compose exec -it conduktor-ctl /bin/sh
-    ````
+    ```
 
 *Conduktor CLI is run as a container for convenience, you can also install it to your local machine.*
 
@@ -184,31 +184,31 @@ Let's swap in the correct key now and assume the role of the website analytics p
 
 You could also run this from the CLI:
 
-````bash 
+```bash 
 conduktor token create application-instance -i=website-analytics-prod my-new-key-name
 eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzUxMiIsImtp...
-````
+```
 
 ![Create Application Instance API key](/images/create-app-api-key.png)
 
 1. Leave the CLI container:
 
-````bash
+```bash
 # You are in the CLI container
 / $ exit
-````
+```
 
 1. Open the `docker-compose.yml` again to swap in the **new value for `CDK_API_KEY`** and restart docker compose again
 
-````bash
+```bash
 docker compose up -d
-````
+```
 
 1. When the container is restarted, step back in the CLI container
 
-````bash
+```bash
 docker compose exec -it conduktor-ctl /bin/sh
-````
+```
 
 With the CLI running using the **application instance API key**, we can properly do the test. Now back to the example.
 

--- a/guide/use-cases/self-service.mdx
+++ b/guide/use-cases/self-service.mdx
@@ -46,7 +46,7 @@ An application represents a streaming app or data pipeline that is responsible f
 
 **Example**
 
-````yaml
+```yaml
 ---
 apiVersion: "self-service/v1"
 kind: "Application"
@@ -56,7 +56,7 @@ spec:
   title: "Clickstream App"
   description: "Clickstream records user’s clicks through their journey on our website"
   owner: "clickstream-group"            # technical-id of the Console Group
-````
+```
 
 ### Application instance
 
@@ -72,7 +72,7 @@ Each Application Instance:
 
 **Example**
 
-````yaml
+```yaml
 # Application Instance (dev environment)
 ---
 apiVersion: "self-service/v1"
@@ -90,7 +90,7 @@ spec:
     - type: CONSUMER_GROUP
       name: "click."
       patternType: PREFIXED
-````
+```
 
 ### Application instance policies
 
@@ -98,7 +98,7 @@ Application Instance Policies restrict the Application Teams to create their res
 
 **Example**
 
-````yaml
+```yaml
 # Policies that restrict the Application to a certain range of configurations
 # on topic configs, but also on topic metadata
 ---
@@ -115,7 +115,7 @@ spec:
       constraint: "Range"
       max: 42
       min: 3
-````
+```
 
 ## Application team resources
 
@@ -128,7 +128,7 @@ Once an Application and Application Instance are defined, Application Teams can 
 
 This is how Application Teams can create the Kafka resources they need for their applications.
 
-````yaml
+```yaml
 # Topic example
 ---
 apiVersion: kafka/v2
@@ -144,7 +144,7 @@ spec:
     cleanup.policy: "delete"
     retention.ms: "60000"
 
-````
+```
 
 ### Application instance permissions
 
@@ -156,7 +156,7 @@ Deploying this object will grant permission to the `grantedTo` Application Insta
 
 **Example**
 
-````yaml
+```yaml
 # Read permission granted to the Heatmap Application on click.screen-events topic
 ---
 apiVersion: self-service/v1
@@ -172,7 +172,7 @@ spec:
     patternType: LITERAL
   permission: READ
   grantedTo: heatmap-app-dev
-````
+```
 
 ### Application group
 
@@ -184,7 +184,7 @@ Create an Application Group to directly reflect how your Application operates. Y
 
 **Example**
 
-````yaml
+```yaml
 # Permissions granted to Console users in the group, CP-COMPANY-CLICKSTREAM-SUPPORT, for the clickstream-app Application
 ---
 apiVersion: self-service/v1
@@ -221,7 +221,7 @@ spec:
   externalGroups:
     - GP-COMPANY-CLICKSTREAM-SUPPORT
 
-````
+```
 
 ### Resource labels
 
@@ -246,7 +246,7 @@ We plan to bring label support to the following resources in the future:
 
 **Example**
 
-````yaml
+```yaml
 # Topic annotated with useful metadata
 ---
 apiVersion: kafka/v2
@@ -267,7 +267,7 @@ spec:
     min.insync.replicas: "2"
     cleanup.policy: "delete"
     retention.ms: "60000"
-````
+```
 
 ## Limited ownership mode
 

--- a/snippets/changelog/Console-1.21.0.mdx
+++ b/snippets/changelog/Console-1.21.0.mdx
@@ -9,9 +9,9 @@ To clarify our product naming we have renamed the Console docker image to `condu
 
 We will publish newer versions using both names for the next **three releases** only. Please modify your installation to reflect this change in advance of us deprecating the name `conduktor-platform`.
 
-````shell
+```shell
 docker pull conduktor/conduktor-console:1.21.0
-````
+```
 
 ### Features
 

--- a/snippets/changelog/Console-1.25.1.mdx
+++ b/snippets/changelog/Console-1.25.1.mdx
@@ -8,9 +8,9 @@ title: Console 1.25.1
 #### New Docker image name
 We have renamed the Console docker image to `conduktor/conduktor-console` to clarify our product naming.  
 Please modify your installation to reflect this change as we will now stop publishing a `conduktor/conduktor-platform` image.
-````shell
+```shell
 docker pull conduktor/conduktor-console:1.25.1
-````
+```
 
 ### Features
 
@@ -33,7 +33,7 @@ Manage your Console resource lifecycle with the addition of the **KafkaCluster**
 
 Checkout the example below and find the full definition at [Console Resources Reference](https://docs.conduktor.io/platform/reference/resource-reference/console/) documentation.
 
-````yaml
+```yaml
 ---
 apiVersion: console/v2
 kind: KafkaCluster
@@ -54,7 +54,7 @@ spec:
       type: BasicAuth
       username: some_user
       password: some_user
-````
+```
 
 #### Short lived token generation on startup
 

--- a/snippets/changelog/Console-1.26.0.mdx
+++ b/snippets/changelog/Console-1.26.0.mdx
@@ -21,7 +21,7 @@ Regardless, as soon as the prometheus team fix this issue, it will be patched im
 
 Continuing with the Infra-as-code approach, we are happy to introduce [CLI support](https://docs.conduktor.io/platform/reference/cli-reference/) for [Connectors](https://docs.conduktor.io/platform/reference/resource-reference/kafka/#connector), providing an efficient and automated way to manage your Kafka Connect resources.
 
-````yaml
+```yaml
 ---
 apiVersion: kafka/v2
 kind: Connector
@@ -36,13 +36,13 @@ spec:
     connector.class: 'org.apache.kafka.connect.tools.MockSourceConnector'
     tasks.max: '1'
     topic: click.pageviews
-````
+```
 
 #### Self-service support for Connectors
 
 Application Teams can now manage their Connectors with Self-service.  
 From now on, you can grant ownership to connectors on Self-service [application instance](https://docs.conduktor.io/platform/reference/resource-reference/self-service/#application-instance).
-````yaml
+```yaml
 ---
 apiVersion: self-service/v1
 kind: ApplicationInstance
@@ -57,7 +57,7 @@ spec:
       connectCluster: shadow-connect
       patternType: PREFIXED
       name: "click."
-````
+```
 
 #### Enhanced UI and graphs for Kafka Connect
 
@@ -95,12 +95,12 @@ Tags written with the naming convention `<key>/<value>` will automatically be ad
 - `<key>: <value>`  
 
 If there is a conflict such as; a topic containing tags with the same key, that already has the target label, or is not written with this naming convention, then they will be created as follows:
-````yaml
+```yaml
 tag-<value>: true
-````
+```
 
 Here's an example of how tags will be migrated into labels:
-````yaml
+```yaml
 # Tags:
 - format/avro
 - project/supplychain
@@ -119,4 +119,4 @@ labels:
   tag-color/red: true # Because conflict on "color"
   tag-wikipedia: true
   tag-non-prod: true
-````
+```

--- a/snippets/changelog/Console-1.27.0.mdx
+++ b/snippets/changelog/Console-1.27.0.mdx
@@ -60,12 +60,12 @@ Tags written with the naming convention `<key>/<value>` will automatically be ad
 - `<key>: <value>`  
 
 If there is a conflict such as; a topic containing tags with the same key, that already has the target label, or is not written with this naming convention, then they will be created as follows:
-````yaml
+```yaml
 tag-<value>: true
-````
+```
 
 Here's an example of how tags will be migrated into labels:
-````yaml
+```yaml
 # Tags:
 - format/avro
 - project/supplychain
@@ -84,7 +84,7 @@ labels:
   tag-color/red: true # Because conflict on "color"
   tag-wikipedia: true
   tag-non-prod: true
-````
+```
 
 **Conduktor can help you rename tags through Customer Support**  
 Between now and the migration, we can help you rename your tags for a smooth transition to labels.  

--- a/snippets/changelog/Console-1.31.0.mdx
+++ b/snippets/changelog/Console-1.31.0.mdx
@@ -48,7 +48,7 @@ Here are some of the changes:
 - Destinations are now configurable per-alert
 - API / CLI support for Alerts is now available
 
-````yaml
+```yaml
 apiVersion: console/v3
 kind: Alert
 metadata:
@@ -64,7 +64,7 @@ spec:
   destination:
     type: Slack
     channel: "alerts-p1"
-````
+```
 Alert creation workflow has been updated to allow you to configure the alert destination and ownership in the UI.
 
 ![Application permissions on RBAC screen](/images/changelog/platform/v31/alerts.png)
@@ -73,7 +73,7 @@ Alert creation workflow has been updated to allow you to configure the alert des
 We have added support for Service Accounts in the API and CLI.  
 Declaring ServiceAccount resource lets you manage the ACLs of a service account in Kafka.  
 At the moment we only support Kafka ACLs (calls to Kafka APIs) but we plan to add support for Aiven ACLs in ServiceAccount resource in the future. 
-````yaml
+```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -99,12 +99,12 @@ spec:
         patternType: LITERAL
         operations:
           - Read
-````
+```
 
 #### Labels support for Service Accounts
 We have added support for labels in the ServiceAccount resource.  
 For now you can only edit labels through ServiceAccount resource in the API and CLI.
-````yaml
+```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -117,7 +117,7 @@ metadata:
     application: clickstream
 spec:
   ...
-````
+```
 The labels are used to filter the Service Accounts in the UI. Editing labels in the UI will be available in the next release.
 ![Application permissions on RBAC screen](/images/changelog/platform/v31/service-account.png)
 
@@ -126,7 +126,7 @@ We have added a new mode for ApplicationInstance that allows Application Teams t
 This mode can be enabled in the ApplicationInstance with the following flag `spec.applicationManagedServiceAccount` set to `true`.  
 When enabled, Self-service will not synchronize the Service Account with the ApplicationInstance and will let the Application Team manage the Service Account directly.
 Application Managed Service Accounts can be declared in the API and CLI using the Application API Key.
-````yaml
+```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -139,7 +139,7 @@ spec:
     type: KAFKA_ACL
     acls:
 ...
-````
+```
 
 ####  Application Group permissions now available on Users Permissions page
 

--- a/snippets/changelog/Console-1.33.0.mdx
+++ b/snippets/changelog/Console-1.33.0.mdx
@@ -30,7 +30,7 @@ We've enhanced permission management for cross-team access. You can now assign d
 
 Here's an example granting READ access to the service account and denying access to members of the application through Console:
 
-````yaml
+```yaml
 # Permission granted to other applications
 ---
 apiVersion: self-service/v1
@@ -47,7 +47,7 @@ spec:
   userPermission: NONE
   serviceAccountPermission: READ
   grantedTo: "another-appinstance-dev"
-````
+```
 
 #### Support for Aiven service accounts
 
@@ -55,7 +55,7 @@ We've added the support for Aiven service accounts in our API and CLI.
 
 Here's an example granting READ and WRITE access to the `click.event-stream.avro` topic and its schema.
 
-````yaml
+```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -72,7 +72,7 @@ spec:
       - type: SCHEMA
         name: 'Subject:click.event-stream.avro'
         permission: schema_registry_write
-````
+```
 
 #### Service account labels
 

--- a/snippets/changelog/Gateway-3.2.0.mdx
+++ b/snippets/changelog/Gateway-3.2.0.mdx
@@ -39,13 +39,13 @@ In the next release, we will enhance ACLs to restore and expand the full set of 
 
 #### Enable ACLs for Gateway (excl. Virtual Clusters)
 Configure both environment variables:
-````shell
+```shell
 GATEWAY_ACL_ENABLED=true
 GATEWAY_SUPER_USERS=alice,bob
-````
+```
 
 #### Enable ACLs for Virtual Clusters
-````yaml
+```yaml
 ---
 apiVersion: gateway/v2
 kind: VirtualCluster
@@ -56,7 +56,7 @@ spec:
   superUsers:
   - username1
   - username2
-````
+```
 This will effectively render `GATEWAY_ACL_STORE_ENABLED` obsolete.
 
 

--- a/snippets/changelog/Gateway-3.2.2.mdx
+++ b/snippets/changelog/Gateway-3.2.2.mdx
@@ -17,9 +17,9 @@ In an **upcoming** release, we will strictly enforce that the username and the t
 
 **This breaking change is due for release 3.5.0.**   
 For this hotfix release 3.2.2, and next product releases 3.3.0 and 3.4.0s, we'll only raise the following warning in the logs:  
-````
+```
 2024-08-27T18:15:29 [WARN] - Inconsistency detected for plain authentication. Username applicationA is not consistent with validated token created for application-A. SASL configuration should be changed accordingly.
-````
+```
 
 ### General fixes 🔨
 

--- a/snippets/changelog/Gateway-3.4.0.mdx
+++ b/snippets/changelog/Gateway-3.4.0.mdx
@@ -17,9 +17,9 @@ Today, the token as the password for local Gateway service accounts contains all
 In release 3.5.0, we will strictly enforce that the username and the token matches. This will help reduce inconsistencies and avoid unexpected behavior.
 
 For this release 3.4.0, we'll only raise the following warning in the logs:  
-````
+```
 2024-08-27T18:15:29 [WARN] - Inconsistency detected for plain authentication. Username applicationA is not consistent with validated token created for application-A. SASL configuration should be changed accordingly.
-````
+```
 
 ***
 
@@ -32,7 +32,7 @@ For this release 3.4.0, we'll only raise the following warning in the logs:
 Concentrated Topics were reporting the offsets of the underlying backing topic. This caused Lag and Message Count metrics to be invalid.
 
 Correct offsets can now be enabled per ConcentrationRule.
-````yaml
+```yaml
 ---
 kind: ConcentrationRule
 metadata:
@@ -43,7 +43,7 @@ spec:
     delete: myapp-concentrated
   autoManaged: false
   offsetCorrectness: true
-````
+```
 
 This feature is experimental and comes with a number of limitations that are important to understand beforehand.
 


### PR DESCRIPTION
This pull request updates documentation across multiple guides to standardize code block formatting. The main change is replacing quadruple backticks (````) with triple backticks (```) for code blocks in markdown files. This ensures consistent rendering and syntax highlighting across the documentation.

The quadruple backticks must only be used to wrap the triple backticks code snippets.
