### PR TITLE
Remove duplicate entries in Fixes

### DIFF
--- a/snippets/changelog/Console-1.37.0.mdx
+++ b/snippets/changelog/Console-1.37.0.mdx
@@ -27,17 +27,15 @@ _Release date: 2025-08-20_
 
 New application group management in Self-service provides full lifecycle management through improved UI workflows.
 
-The **Members** tab offers an enhanced interface for managing group membership, making it easier for teams to control access and visibility. The **Resource access** tab enables granular control over topic, consumer group, subject, and connector permissions for precise access management. Application groups can also map to external groups like Console user groups for streamlined access management. 
+The **Members** tab offers an enhanced interface for managing group membership, making it easier for teams to control access and visibility. The **Resource access** tab enables granular control over topic, consumer group, subject, and connector permissions for precise access management. Application groups can also map to external groups like Console user groups for streamlined access management.
 
 #### Application Instance resources
 
 Application instances now feature comprehensive resource management capabilities. The new **Resources** tab provides a detailed view of all the resources associated with application instances, giving teams better visibility into their resource usage and dependencies.
 
-
 #### Subject strategies support
 
 Support for **Confluent subject strategies** has been added to the produce page for topics. This enhancement gives users more control over how schemas are referenced when producing messages, providing flexibility in schema organization and naming conventions.
-
 
 #### External Group management improvements
 
@@ -91,23 +89,15 @@ You can now fine-tune Cortex and Prometheus retention with the new environment v
 
 You can **patch** (instead of replacing) the YAML configuration. [Find out more about overriding the configuration with YAML](/guide/conduktor-in-production/deploy-artifacts/deploy-cortex#overriding-with-yaml).
 
-The Self-service experience has been improved with **updated terminology** for managing access requests. 
+The Self-service experience has been improved with **updated terminology** for managing access requests.
 
 Ambiguous and inconsistent references to various terminology such as 'subscriptions', 'subscribing', 'access requests', 'sharing', 'requests', have been standardized throughout the application, placing emphasis on a single unified concept of **access request**.
 
 You can now view the Resource Policies in the Application details page, and the Consumer Group ownerships in the Application instance details page.
-
 
 ### Fixes
 
 - Fixed production rate metrics getting stuck at high values when producer rates drop instantly to zero, which was causing artificially inflated metrics in systems with bursty production patterns.
 - Errors preventing users from logging in are now prominently displayed on the login page.
 - The Trust Rules and Policies pages are now hidden for users without [Trust](https://conduktor.io/trust) in their license.
- - Fixed production rate metrics getting stuck at high values when producer rates drop instantly to zero, which was causing artificially inflated metrics in systems with bursty production patterns
- - Errors preventing users from logging in are now prominently displayed on the login page
- - The Trust Rules and Policies pages are now hidden for users without [Trust](https://conduktor.io/trust) in their license
- - Kafka Cluster configuration for SSL passwords no longer displays length unless editing the field, and AWS Glue secrets are no longer clear text.
-- Fixed production rate metrics getting stuck at high values when producer rates drop instantly to zero, which was causing artificially inflated metrics in systems with bursty production patterns
-- Errors preventing users from logging in are now prominently displayed on the login page
-- The Trust Rules and Policies pages are now hidden for users without [Trust](https://conduktor.io/trust) in their license
 - Kafka Cluster configuration for SSL passwords no longer displays length unless editing the field, and AWS Glue secrets are no longer clear text.


### PR DESCRIPTION
Duplicate entires were accidentally introduced in [this PR merge](https://github.com/conduktor/conduktor-docs/pull/928/files).

Also ran `prettier` formatting in the file.