### PR TITLE
Multi Cluster Doc Update + Gateway CUS Tickets

### DIFF
--- a/guide/tutorials/partner-zone-multi-cluster.mdx
+++ b/guide/tutorials/partner-zone-multi-cluster.mdx
@@ -81,8 +81,8 @@ Assuming that we have a `gateway-main` Gateway cluster and a `clusterA` Kafka cl
 <Tab title="Using Console UI">
 1. Go to the **Partner Zones** page in Console.
 2. Click on **Create Partner Zone**.
-3. Select the **Gateway Cluster** as `gateway-main`.
-4. Select the **Underlying Cluster** as `clusterA`.
+3. **Select Gateway** to choose the gateway to use i.e. `gateway-main`.
+4. **Select a cluster** to choose an available underlying cluster i.e. `clusterA`.
 5. Select the topics you want to include in the Partner Zone, and optionally create any topic aliases.
 6. Fill in and complete the remaining steps to create the Partner Zone.
 7. Finally click **Create** to create the Partner Zone.

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -20,8 +20,8 @@ Partner Zones allow you to share Kafka topics with external partners selectively
 
 Before creating a Partner Zone, you have to:
 
-- use **Conduktor Console 1.36.0** or later
-- use **Conduktor Gateway 3.11.0** or later with the following configurations:
+- use **Conduktor Console 1.37.0** or later
+- use **Conduktor Gateway 3.12.0** or later with the following configurations:
   - `GATEWAY_SECURITY_PROTOCOL` set to `SSL`, `SASL_SSL`, or `SASL_PLAINTEXT`
   - `GATEWAY_SECURITY_MODE` set to `GATEWAY_MANAGED`
   - `GATEWAY_USER_POOL_SERVICE_ACCOUNT_REQUIRED` set to `true`

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -114,7 +114,7 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
           phone: 07827 837 177
     ```
 
-For [multi-cluster configured](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters) Gateways, targeting an upstream Kafka cluster requires supplying its technical cluster ID. The `cluster` field corresponds to the technical ID of the Gateway you plan to target. `underlyingCluster` corresponds to the technical ID of the chosen Kafka cluster to target.
+Use `underlyingCluster` to target an upstream physical cluster in a [multi-cluster configured](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters) Gateway. The cluster also needs to be configured in the Console and you will need to use the technical id from that configuration to populate this field.
 
 <Info>
 `underlyingCluster` is optional. When not set the main physical cluster on the Gateway is used.

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -117,7 +117,7 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
 For [multi-cluster configured](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters) Gateways, targeting an upstream Kafka cluster requires supplying its technical cluster ID. The `cluster` field corresponds to the technical ID of the Gateway you plan to target. `underlyingCluster` corresponds to the technical ID of the chosen Kafka cluster to target.
 
 <Info>
-    If underlyingCluster is unset, it will default to the value of `cluster`. As a result the main cluster will be targeted as opposed to the upstream clusters.
+`underlyingCluster` is optional. When not set the main physical cluster on the Gateway is used.
 </Info>
 
 

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -54,7 +54,7 @@ Use the Console UI to create a Partner Zone in just a few steps.
    - (Optional) Specify contact details of the beneficiary/recipient of this Partner Zone.
    - **Select Gateway** to choose the one you want to use, then select an available cluster under the Gateway and click **Continue**.
      - [Find out how to configure Gateway for multiple clusters](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters).
-     - Only clusters that have also been configured in Console will be available to select. There is a tutorial for [configuring Gateway and Console to support multi-cluster Partnerzones](/guide/tutorials/partner-zone-multi-cluster)
+     - Only clusters that have also been configured in Console will be available to select. See the [Partner Zone multi-cluster tutorial](/guide/tutorials/partner-zone-multi-cluster#configure-the-underlying-kafka-clusters-in-console) on how to configure the underlying clusters in Console.
 1. Choose what and how to share:
    - **Select the Kafka topics** to include in this Partner Zone, you can filter topics by custom labels you've defined or search for topic name.
    - **Select Read/Write**. By default, any topics that are shared, will be shared with **Read**-only access, but you can additionally allow **Write** access.

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -53,7 +53,8 @@ Use the Console UI to create a Partner Zone in just a few steps.
    - (Optional) Enter a **Description** to explain your reasons/requirements for sharing data.
    - (Optional) Specify contact details of the beneficiary/recipient of this Partner Zone.
    - **Select Gateway** to choose the one you want to use, then select an available cluster under the Gateway and click **Continue**.
-     - [Find out how to configure multi-cluster configured Gateway](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters).
+     - [Find out how to configure Gateway for multiple clusters](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters).
+     - Only clusters that have also been configured in Console will be available to select. There is a tutorial for [configuring Gateway and Console to support multi-cluster Partnerzones](/guide/tutorials/partner-zone-multi-cluster)
 1. Choose what and how to share:
    - **Select the Kafka topics** to include in this Partner Zone, you can filter topics by custom labels you've defined or search for topic name.
    - **Select Read/Write**. By default, any topics that are shared, will be shared with **Read**-only access, but you can additionally allow **Write** access.

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -114,7 +114,8 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
           phone: 07827 837 177
     ```
 
-Use `underlyingCluster` to target an upstream physical cluster in a [multi-cluster configured](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters) Gateway. The cluster also needs to be configured in the Console and you will need to use the technical id from that configuration to populate this field.
+* The `cluster` field corresponds to the technical ID of the Gateway.
+* Use `underlyingCluster` to target an upstream physical cluster in a [multi-cluster configured](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters) Gateway. The upstream cluster also needs to be configured in the Console and the technical ID from that configuration will populate this field.
 
 <Info>
 `underlyingCluster` is optional. When not set the main physical cluster on the Gateway is used.

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -111,11 +111,13 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
           email: johndoe@company.io
           phone: 07827 837 177
     ```
-For [multi cluster configured]((/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters)) Gateways, to target a non main backing Kafka cluster you must supply its technical cluster ID. `cluster` field requires supplying the technical ID of the Gateway you plan to target. `underlyingCluster` refers to the technical ID of the chosen Kafka cluster to target. 
 
-     <Info>
-         If underlyingCluster is unset, it will default to the value of `cluster`.
-     </Info>
+For [multi-cluster configured](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters) Gateways, targeting an upstream Kafka cluster requires supplying its technical cluster ID. The `cluster` field corresponds to the technical ID of the Gateway you plan to target. `underlyingCluster` corresponds to the technical ID of the chosen Kafka cluster to target.
+
+<Info>
+    If underlyingCluster is unset, it will default to the value of `cluster`. As a result the main cluster will be targeted as opposed to the upstream clusters.
+</Info>
+
 
 1. Use [Conduktor CLI](/guide/conduktor-in-production/automate/cli-automation) to apply the configuration:
 

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -111,7 +111,7 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
           email: johndoe@company.io
           phone: 07827 837 177
     ```
-    * If your Gateway is [setup with multi-clusters](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters), you must additionally provide an `underlyingCluster` field. `cluster` will be the technical cluster Id of the Gateway as before, and `underlyingCluster` will be the cluster Id of the underlying cluster configured under the Gateway. The `underlyingCluster` field is used as the Console cluster Id.
+    * If your Gateway is [setup with multi-clusters](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters), you must additionally provide an `underlyingCluster` field. `cluster` will be the technical cluster Id of the Gateway as before, and `underlyingCluster` will be the cluster Id of the underlying cluster configured under the Gateway. The `underlyingCluster` field is used as the Console cluster ID.
 
      <Info>
          If underlyingCluster is unset, it will default to the value of `cluster`.

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -93,7 +93,6 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
         name: external-partner-zone
     spec:
         cluster: partner1
-        underlyingCluster: partner1
         displayName: External Partner Zone
         url: https://partner1.com
         authenticationMode:
@@ -112,10 +111,10 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
           email: johndoe@company.io
           phone: 07827 837 177
     ```
-    * If your Gateway is [setup with multi-clusters](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters), `cluster` will be the technical cluster Id of the Gateway as before, and `underlyingCluster` will be the cluster Id of the underlying cluster configured under the Gateway. The `underlyingCluster` is used as the Console cluster Id.
+    * If your Gateway is [setup with multi-clusters](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters), you must additionally provide an `underlyingCluster` field. `cluster` will be the technical cluster Id of the Gateway as before, and `underlyingCluster` will be the cluster Id of the underlying cluster configured under the Gateway. The `underlyingCluster` field is used as the Console cluster Id.
 
      <Info>
-         If underlyingCluster is unset, it will default to the value of `cluster`
+         If underlyingCluster is unset, it will default to the value of `cluster`.
      </Info>
 
 1. Use [Conduktor CLI](/guide/conduktor-in-production/automate/cli-automation) to apply the configuration:

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -111,7 +111,7 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
           email: johndoe@company.io
           phone: 07827 837 177
     ```
-    * If your Gateway is [setup with multi-clusters](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters), you must additionally provide an `underlyingCluster` field. `cluster` will be the technical cluster Id of the Gateway as before, and `underlyingCluster` will be the cluster Id of the underlying cluster configured under the Gateway. The `underlyingCluster` field is used as the Console cluster ID.
+For [multi cluster configured]((/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters)) Gateways, to target a non main backing Kafka cluster you must supply its technical cluster ID. `cluster` field requires supplying the technical ID of the Gateway you plan to target. `underlyingCluster` refers to the technical ID of the chosen Kafka cluster to target. 
 
      <Info>
          If underlyingCluster is unset, it will default to the value of `cluster`.

--- a/guide/use-cases/third-party-data.mdx
+++ b/guide/use-cases/third-party-data.mdx
@@ -31,7 +31,7 @@ Before creating a Partner Zone, you have to:
 - in Console, [configure your Gateway cluster](/guide/conduktor-in-production/admin/configure-clusters) and fill in the **Provider** tab with Gateway API credentials
 
 <Warning>
-As of v1.36.0, Partner Zones have the following limitations:
+Partner Zones currently have the following limitations:
 
 - Passwords do not expire. If you need **to revoke access** to your partner, you will have to delete the Partner Zone.
 </Warning>
@@ -52,7 +52,8 @@ Use the Console UI to create a Partner Zone in just a few steps.
    - (Optional) Enter a relevant **URL** for your partner.
    - (Optional) Enter a **Description** to explain your reasons/requirements for sharing data.
    - (Optional) Specify contact details of the beneficiary/recipient of this Partner Zone.
-   - **Select Gateway** to choose the one you want to use and click **Continue**.
+   - **Select Gateway** to choose the one you want to use, then select an available cluster under the Gateway and click **Continue**.
+     - [Find out how to configure multi-cluster configured Gateway](/guide/conduktor-in-production/deploy-artifacts/deploy-gateway/index#configure-gateway-for-multi-clusters).
 1. Choose what and how to share:
    - **Select the Kafka topics** to include in this Partner Zone, you can filter topics by custom labels you've defined or search for topic name.
    - **Select Read/Write**. By default, any topics that are shared, will be shared with **Read**-only access, but you can additionally allow **Write** access.
@@ -92,7 +93,8 @@ You can also use the [Conduktor CLI (Command Line Interface)](/guide/conduktor-i
     metadata:
         name: external-partner-zone
     spec:
-        cluster: partner1
+        cluster: gateway-1
+        underlyingCluster: kafka-cluster-1
         displayName: External Partner Zone
         url: https://partner1.com
         authenticationMode:
@@ -138,8 +140,8 @@ For [multi-cluster configured](/guide/conduktor-in-production/deploy-artifacts/d
         updatedAt: "2025-01-27T12:55:05.387368Z"
         status: PENDING
     spec:
-        cluster: partner1
-        underlyingCluster: partner1
+        cluster: gateway-1
+        underlyingCluster: kafka-cluster-1
         displayName: External Partner Zone
         url: https://partner1.com
         serviceAccount: external-partner-service-account

--- a/snippets/changelog/Console-1.37.0.mdx
+++ b/snippets/changelog/Console-1.37.0.mdx
@@ -53,7 +53,7 @@ Partner Zones are now generally available and out of preview. This means that al
 
 Console now supports creating Partner Zones against a multi-clustered Gateway configuration. This allows for a Partner Zone to be created against any of the configured Kafka clusters behind Gateway (previously, a Gateway was required per Kafka cluster for a Partner Zone).
 
-[Check out the tutorial on creating Partner Zones with multi-cluster Gateway](/guide/tutorials/partner-zone-multi-cluster).
+[Check out the tutorial on creating Partner Zones with multi-cluster Gateway](/guide/tutorials/partner-zone-multi-cluster), as well as the [console resources for Partner Zones](/guide/reference/console-reference#partner-zones).
 
 #### Partner Zone breaking change
 
@@ -62,8 +62,8 @@ With the support for multi-cluster Gateway, all existing Partner Zones created p
 **Action required:**
 
 - Delete all existing Partner Zones before upgrading
-- Upgrade to the latest version
-- Recreate your Partner Zones with the new configuration
+- Upgrade Console and Gateway to the latest version
+- Recreate the Partner Zones with the same configuration
 
 ### Conduktor Trust
 

--- a/snippets/changelog/Gateway-3.12.0.mdx
+++ b/snippets/changelog/Gateway-3.12.0.mdx
@@ -5,7 +5,6 @@ title: Gateway 3.12.0
 
 - [Breaking changes](#breaking-changes)
   - [New APIs for health and versions](#new-apis-for-health-and-versions)
-  - [Configuration key change for Vault KUBERNETES authentication type](#configuration-key-change-for-vault-kubernetes-authentication-type)
   - [Rename of the Virtual Cluster Id](#rename-of-virtual-cluster-id)
 - [New features](#new-features)
   - [New `GATEWAY_AUDIT_LOG_EVENT_TYPES` environment variable](#new-gateway_audit_log_event_types-environment-variable)
@@ -30,14 +29,6 @@ The old */health* API is now deprecated but it will continue to function.
 Please update your configuration to use the new liveness and readiness probe endpoints.
 </Warning>
 
-#### Configuration key change for Vault KUBERNETES authentication type
-
-The [Vault KUBERNETES authentication type](https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth/methods/kubernetes#token_path) has been corrected to read the token from a file in the running pod.
-
-Because of this, Kubernetes authentication's configuration key `jwt` (`VAULT_KUBERNETES_JWT`) was changed to `path` (`VAULT_KUBERNETES_PATH`). 
-
-This *optional* configuration contains the path of the file containing the token. It defaults to `/var/run/secrets/kubernetes.io/serviceaccount/token` following the Vault documentation.
-
 #### Rename of Virtual Cluster Id
 
 When a Kafka client requests the cluster Id of a Virtual Cluster through Gateway, the returned cluster Id will be different - it will be renamed.
@@ -45,6 +36,7 @@ When a Kafka client requests the cluster Id of a Virtual Cluster through Gateway
 Previously, the returned cluster Id was the native Kafka cluster Id of the Virtual Cluster's physical cluster.
 
 The new cluster Id that's returned will be be in the form of: `{virtual-cluster-name}@{physical-cluster-id}`.
+
 
 ### New features
 
@@ -76,7 +68,7 @@ Gateway now supports client throttling when encryption or decryption operations 
 
 ### Fixes
 
-- Fixed `KUBERNETES` authentication for Vault to automatically read the JWT token from the default service account path, eliminating the need for manual JWT configuration.
+- Fixed `KUBERNETES` authentication for Vault to automatically read the JWT token from the default service account path at `/var/run/secrets/kubernetes.io/serviceaccount/token`, eliminating the need for manual JWT configuration. Configuration key changed from `jwt` (`VAULT_KUBERNETES_JWT`) to `path` (`VAULT_KUBERNETES_PATH`).
 
 - Enhanced Gateway audit logging to include request body content for token creation operations, improving security auditing capabilities.
 

--- a/snippets/changelog/Gateway-3.12.0.mdx
+++ b/snippets/changelog/Gateway-3.12.0.mdx
@@ -76,12 +76,12 @@ Gateway now supports client throttling when encryption or decryption operations 
 
 ### Fixes
 
-- Fixed KUBERNETES authentication for Vault to automatically read the JWT token from the default service account path, eliminating the need for manual JWT configuration. [CUS-734](https://linear.app/conduktor/issue/CUS-734/lloyds-banking-group-kubernetes-auth-support-for-vault)
+- Fixed `KUBERNETES` authentication for Vault to automatically read the JWT token from the default service account path, eliminating the need for manual JWT configuration.
 
-- Enhanced Gateway audit logging to include request body content for token creation operations, improving security auditing capabilities. [CUS-685](https://linear.app/conduktor/issue/CUS-685/sainsburys-gateway-audit-log-doesnt-show-request-body)
+- Enhanced Gateway audit logging to include request body content for token creation operations, improving security auditing capabilities.
 
-- Resolved GATEWAY_TOPIC_STORE_KCACHE_REPLICATION_FACTOR configuration to properly default to the Kafka cluster's default replication factor settings. [CUS-563](https://linear.app/conduktor/issue/CUS-563/six-gateway-topic-store-kcache-replication-factor-doesnt-default-to)
+- Resolved `GATEWAY_TOPIC_STORE_KCACHE_REPLICATION_FACTOR` configuration to properly default to the Kafka cluster's default replication factor settings.
 
-- Added support for Protobuf schema validation in the schema payload validation interceptor, enabling comprehensive schema governance for Protobuf-based applications. [CUS-727](https://linear.app/conduktor/issue/CUS-727/lloyds-banking-group-protobuf-schema-is-not-supported-for-schema)
+- Added support for Protobuf schema validation in the schema payload validation interceptor, enabling comprehensive schema governance for Protobuf-based applications.
 
-- Improved SSL handshake failure logging to include client IP addresses, enhancing troubleshooting capabilities for mTLS configurations. [CUS-713](https://linear.app/conduktor/issue/CUS-713/lufthansa-capture-the-ip-address-of-the-client-in-case-of-ssl)
+- Improved SSL handshake failure logging to include client IP addresses, enhancing troubleshooting capabilities for `mTLS` configurations.

--- a/snippets/changelog/Gateway-3.12.0.mdx
+++ b/snippets/changelog/Gateway-3.12.0.mdx
@@ -68,12 +68,12 @@ Gateway now supports client throttling when encryption or decryption operations 
 
 ### Fixes
 
-- Fixed `KUBERNETES` authentication for Vault to automatically read the JWT token from the default service account path at `/var/run/secrets/kubernetes.io/serviceaccount/token`, eliminating the need for manual JWT configuration. Configuration key changed from `jwt` (`VAULT_KUBERNETES_JWT`) to `path` (`VAULT_KUBERNETES_PATH`).
+- `KUBERNETES` Vault authentication now gets the JWT from the default Vault location (`/var/run/secrets/kubernetes.io/serviceaccount/token`). You can configure this location using `path` (`VAULT_KUBERNETES_PATH`). The `jwt` configuration key is no longer needed.
 
-- Fixed Gateway audit logging to properly capture request body content in `REST_API` audit events, which was previously showing as `null` for operations like token creation.
+- Enriched the `REST_API` audit log events with the request body, which was previously not captured.
 
 - Resolved `GATEWAY_TOPIC_STORE_KCACHE_REPLICATION_FACTOR` configuration to properly default to the Kafka cluster's default replication factor settings.
 
-- Fixed schema payload validation interceptor to support Protobuf schemas, which were previously rejected with "protobuf schema is not supported" errors when applied to messages.
+- Supported Protobuf schemas for `SchemaPayloadValidationPolicyPlugin`.
 
 - Updated SSL handshake failure logging to include client IP addresses, which were previously missing from error logs, helping identify which applications are affected by certificate issues.

--- a/snippets/changelog/Gateway-3.12.0.mdx
+++ b/snippets/changelog/Gateway-3.12.0.mdx
@@ -70,10 +70,10 @@ Gateway now supports client throttling when encryption or decryption operations 
 
 - Fixed `KUBERNETES` authentication for Vault to automatically read the JWT token from the default service account path at `/var/run/secrets/kubernetes.io/serviceaccount/token`, eliminating the need for manual JWT configuration. Configuration key changed from `jwt` (`VAULT_KUBERNETES_JWT`) to `path` (`VAULT_KUBERNETES_PATH`).
 
-- Enhanced Gateway audit logging to include request body content for API requests, improving auditing capabilities.
+- Fixed Gateway audit logging to properly capture request body content in `REST_API` audit events, which was previously showing as `null` for operations like token creation.
 
 - Resolved `GATEWAY_TOPIC_STORE_KCACHE_REPLICATION_FACTOR` configuration to properly default to the Kafka cluster's default replication factor settings.
 
-- Added support for Protobuf schema validation in the schema payload validation interceptor, enabling comprehensive schema governance for Protobuf-based applications.
+- Fixed schema payload validation interceptor to support Protobuf schemas, which were previously rejected with "protobuf schema is not supported" errors when applied to messages.
 
-- Improved SSL handshake failure logging to include client IP addresses, enhancing troubleshooting capabilities for `mTLS` configurations.
+- Updated SSL handshake failure logging to include client IP addresses, which were previously missing from error logs, helping identify which applications are affected by certificate issues.

--- a/snippets/changelog/Gateway-3.12.0.mdx
+++ b/snippets/changelog/Gateway-3.12.0.mdx
@@ -70,7 +70,7 @@ Gateway now supports client throttling when encryption or decryption operations 
 
 - Fixed `KUBERNETES` authentication for Vault to automatically read the JWT token from the default service account path at `/var/run/secrets/kubernetes.io/serviceaccount/token`, eliminating the need for manual JWT configuration. Configuration key changed from `jwt` (`VAULT_KUBERNETES_JWT`) to `path` (`VAULT_KUBERNETES_PATH`).
 
-- Enhanced Gateway audit logging to include request body content for token creation operations, improving security auditing capabilities.
+- Enhanced Gateway audit logging to include request body content for API requests, improving auditing capabilities.
 
 - Resolved `GATEWAY_TOPIC_STORE_KCACHE_REPLICATION_FACTOR` configuration to properly default to the Kafka cluster's default replication factor settings.
 

--- a/snippets/changelog/Gateway-3.12.0.mdx
+++ b/snippets/changelog/Gateway-3.12.0.mdx
@@ -11,6 +11,8 @@ title: Gateway 3.12.0
   - [New `GATEWAY_AUDIT_LOG_EVENT_TYPES` environment variable](#new-gateway_audit_log_event_types-environment-variable)
   - [Enhanced crypto shredding behavior for decryption](#enhanced-crypto-shredding-behavior-for-decryption)
   - [Client throttling for encryption and decryption](#client-throttling-for-encryption-and-decryption)
+- [Fixes](#fixes)
+  
 
 ### Breaking changes
 
@@ -70,3 +72,16 @@ Gateway now supports client throttling when encryption or decryption operations 
 - **Configurable behavior**: You can enable and adjust throttling based on your system's needs and error tolerance
 
 [Find out more about encryption and decryption configurations](/gateway/interceptors/data-security/encryption/).
+
+
+### Fixes
+
+- Fixed KUBERNETES authentication for Vault to automatically read the JWT token from the default service account path, eliminating the need for manual JWT configuration. [CUS-734](https://linear.app/conduktor/issue/CUS-734/lloyds-banking-group-kubernetes-auth-support-for-vault)
+
+- Enhanced Gateway audit logging to include request body content for token creation operations, improving security auditing capabilities. [CUS-685](https://linear.app/conduktor/issue/CUS-685/sainsburys-gateway-audit-log-doesnt-show-request-body)
+
+- Resolved GATEWAY_TOPIC_STORE_KCACHE_REPLICATION_FACTOR configuration to properly default to the Kafka cluster's default replication factor settings. [CUS-563](https://linear.app/conduktor/issue/CUS-563/six-gateway-topic-store-kcache-replication-factor-doesnt-default-to)
+
+- Added support for Protobuf schema validation in the schema payload validation interceptor, enabling comprehensive schema governance for Protobuf-based applications. [CUS-727](https://linear.app/conduktor/issue/CUS-727/lloyds-banking-group-protobuf-schema-is-not-supported-for-schema)
+
+- Improved SSL handshake failure logging to include client IP addresses, enhancing troubleshooting capabilities for mTLS configurations. [CUS-713](https://linear.app/conduktor/issue/CUS-713/lufthansa-capture-the-ip-address-of-the-client-in-case-of-ssl)


### PR DESCRIPTION
- Updated the wording for the multi-cluster partner zone docs
- Added the fixes from the CUS tickets to the gateway release docs

CUS tickets added to the fix section:
 1. CUS-734 - Lloyd's Banking Group - KUBERNETES auth support for Vault
 https://linear.app/conduktor/issue/CUS-734/lloyds-banking-group-kubernetes-auth-support-for-vault
 1. CUS-685 - Sainsbury's - Gateway audit log doesn't show request body
 https://linear.app/conduktor/issue/CUS-685/sainsburys-gateway-audit-log-doesnt-show-request-body
 1. CUS-563 - SIX - GATEWAY_TOPIC_STORE_KCACHE_REPLICATION_FACTOR doesn't default to Kafka default
https://linear.app/conduktor/issue/CUS-563/six-gateway-topic-store-kcache-replication-factor-doesnt-default-to
 1. CUS-727 - Lloyd's Banking Group - Protobuf schema is not supported for schema payload validation
  interceptor
https://linear.app/conduktor/issue/CUS-727/lloyds-banking-group-protobuf-schema-is-not-supported-for-schema
 1. CUS-713 - Lufthansa - Capture the IP address of the client in case of SSL Handshake failure
https://linear.app/conduktor/issue/CUS-713/lufthansa-capture-the-ip-address-of-the-client-in-case-of-ssl