### PR TITLE
Add missing JSON closing tag which is possibly breaking page

### DIFF
--- a/guide/reference/interceptor-reference.mdx
+++ b/guide/reference/interceptor-reference.mdx
@@ -902,3 +902,4 @@ When `throttleTimeMs` is configured with a value greater than 0:
     // ... other configuration
   }
 }
+```


### PR DESCRIPTION
I found there was a missing closing tag to one of the JSON blocks. This might be why **Interceptor reference** is inaccessible at https://docs.conduktor.io/guide/reference